### PR TITLE
Allow for .precious.toml as an alternate default config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ customize this as needed to install only the tools you need for your project.
 
 ## Configuration
 
-Precious is configured via a single `precious.toml` file that lives in your
-project root. The file is in [TOML format](https://github.com/toml-lang/toml).
+Precious is configured via a single `precious.toml` or `.precious.toml` file
+that lives in your project root. The file is in [TOML
+format](https://github.com/toml-lang/toml).
 
 There is just one key that can be set in the top level table of the config file:
 

--- a/src/precious.rs
+++ b/src/precious.rs
@@ -684,8 +684,7 @@ impl<'a> Precious<'a> {
     }
 
     fn has_config_file(path: &Path) -> bool {
-        let file = Self::default_config_file(path);
-        return file.exists();
+        Self::default_config_file(path).exists()
     }
 }
 

--- a/src/precious.rs
+++ b/src/precious.rs
@@ -683,13 +683,7 @@ impl<'a> Precious<'a> {
     }
 
     fn has_config_file(path: &Path) -> bool {
-        let mut file = path.to_path_buf();
-        file.push(".precious.toml");
-        if file.exists() {
-            return true;
-        }
-        file.pop();
-        file.push("precious.toml");
+        let file = Self::default_config_file(path);
         return file.exists();
     }
 }

--- a/src/precious.rs
+++ b/src/precious.rs
@@ -304,10 +304,11 @@ impl<'a> Precious<'a> {
     }
 
     fn default_config_file(root: &Path) -> PathBuf {
-        let mut file = root.to_path_buf();
+        let root_path = root.to_path_buf();
+        let mut file = root_path.clone();
         file.push(".precious.toml");
         if !file.exists() {
-            file.pop();
+            file = root_path.clone();
             file.push("precious.toml");
         }
         file

--- a/src/precious.rs
+++ b/src/precious.rs
@@ -748,10 +748,12 @@ ok_exit_codes = [0]
 lint_failure_exit_codes = [1]
 "#;
 
+    const CONFIG_FILE_NAME: &str = "precious.toml";
+
     #[test]
     #[serial]
     fn new() -> Result<()> {
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", SIMPLE_CONFIG)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, SIMPLE_CONFIG)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -763,7 +765,7 @@ lint_failure_exit_codes = [1]
 
         let (_, config_file) = Precious::config(&matches, &p.root)?;
         let mut expect_config_file = p.root;
-        expect_config_file.push("precious.toml");
+        expect_config_file.push(CONFIG_FILE_NAME);
         assert_eq!(config_file, expect_config_file);
 
         Ok(())
@@ -793,7 +795,7 @@ lint_failure_exit_codes = [1]
     #[test]
     #[serial]
     fn new_with_ascii_flag() -> Result<()> {
-        let helper = testhelper::TestHelper::new()?.with_config_file(SIMPLE_CONFIG)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, SIMPLE_CONFIG)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -808,14 +810,14 @@ lint_failure_exit_codes = [1]
     #[test]
     #[serial]
     fn new_with_config_path() -> Result<()> {
-        let helper = testhelper::TestHelper::new()?.with_config_file(SIMPLE_CONFIG)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, SIMPLE_CONFIG)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
         let matches = app.try_get_matches_from(&[
             "precious",
             "--config",
-            helper.config_file().to_str().unwrap(),
+            helper.config_file(CONFIG_FILE_NAME).to_str().unwrap(),
             "tidy",
             "--all",
         ])?;
@@ -824,7 +826,7 @@ lint_failure_exit_codes = [1]
 
         let (_, config_file) = Precious::config(&matches, &p.root)?;
         let mut expect_config_file = p.root;
-        expect_config_file.push("precious.toml");
+        expect_config_file.push(CONFIG_FILE_NAME);
         assert_eq!(config_file, expect_config_file);
 
         Ok(())
@@ -838,7 +840,7 @@ lint_failure_exit_codes = [1]
         let mut src_dir = helper.root();
         src_dir.push("src");
         let mut subdir_config = src_dir.clone();
-        subdir_config.push("precious.toml");
+        subdir_config.push(CONFIG_FILE_NAME);
         helper.write_file(&subdir_config, SIMPLE_CONFIG)?;
         let _pushd = testhelper::Pushd::new(src_dir.clone())?;
 
@@ -855,7 +857,7 @@ lint_failure_exit_codes = [1]
     #[serial]
     fn basepaths_uses_cwd() -> Result<()> {
         let helper = testhelper::TestHelper::new()?
-            .with_config_file("precious.toml", SIMPLE_CONFIG)?
+            .with_config_file(CONFIG_FILE_NAME, SIMPLE_CONFIG)?
             .with_git_repo()?;
 
         let mut src_dir = helper.root();
@@ -890,7 +892,7 @@ include = "**/*"
 cmd     = ["true"]
 ok_exit_codes = [0]
 "#;
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", config)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, config)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -914,7 +916,7 @@ include = "**/*"
 cmd     = ["false"]
 ok_exit_codes = [0]
 "#;
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", config)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, config)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -939,7 +941,7 @@ cmd     = ["true"]
 ok_exit_codes = [0]
 lint_failure_exit_codes = [1]
 "#;
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", config)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, config)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -964,7 +966,7 @@ cmd     = ["false"]
 ok_exit_codes = [0]
 lint_failure_exit_codes = [1]
 "#;
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", config)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, config)?;
         let _pushd = helper.pushd_to_root()?;
 
         let app = app();
@@ -1012,7 +1014,7 @@ cmd     = ["perl", "-pi", "-e", "s/a/d/i"]
 ok_exit_codes = [0]
 lint_failure_exit_codes = [1]
 "#;
-        let helper = testhelper::TestHelper::new()?.with_config_file("precious.toml", config)?;
+        let helper = testhelper::TestHelper::new()?.with_config_file(CONFIG_FILE_NAME, config)?;
         let test_replace = PathBuf::from_str("test.replace")?;
         helper.write_file(test_replace.as_ref(), "The letter A")?;
         let _pushd = helper.pushd_to_root()?;

--- a/src/testhelper.rs
+++ b/src/testhelper.rs
@@ -50,11 +50,11 @@ impl TestHelper {
         Ok(self)
     }
 
-    pub fn with_config_file(self, content: &str) -> Result<Self> {
+    pub fn with_config_file(self, file_name: &str, content: &str) -> Result<Self> {
         if cfg!(windows) {
-            self.write_file(&self.config_file(), &content.replace("\n", "\r\n"))?;
+            self.write_file(&self.config_file(file_name), &content.replace("\n", "\r\n"))?;
         } else {
-            self.write_file(&self.config_file(), content)?;
+            self.write_file(&self.config_file(file_name), content)?;
         }
         Ok(self)
     }
@@ -141,9 +141,9 @@ impl TestHelper {
         self.root.clone()
     }
 
-    pub fn config_file(&self) -> PathBuf {
+    pub fn config_file(&self, file_name: &str) -> PathBuf {
         let mut path = self.root.clone();
-        path.push("precious.toml");
+        path.push(file_name);
         path
     }
 


### PR DESCRIPTION
- Allow for .precious.toml as a default config file name
- Use a constant for precious.toml in tests

Fixes #13