### PR TITLE
Add expect_stderr = true to Perl::Critic example

### DIFF
--- a/examples/perl/precious.toml
+++ b/examples/perl/precious.toml
@@ -47,6 +47,7 @@ include = [ "**/*.{pl,pm,t,psgi}" ]
 cmd = [ "perlcritic", "--profile=$PRECIOUS_ROOT/perlcriticrc" ]
 ok_exit_codes = 0
 lint_failure_exit_codes = 2
+expect_stderr = true
 
 # Add Perl::Tidy as a develop phase prereq
 [commands.perltidy]


### PR DESCRIPTION
Perl::Critic can emit a warning without claiming that there has been a
violation:

https://metacpan.org/release/PETDANCE/Perl-Critic-StricterSubs-0.06/source/lib/Perl/Critic/Policy/Subroutines/ProhibitCallsToUnexportedSubs.pm#L198

This one bit me because I copy/pasted the example from this repo and
just one file started failing for seemingly mysterious reasons.
