### PR TITLE
Check for a command name earlier in filter building function

### DIFF
--- a/precious-core/src/config.rs
+++ b/precious-core/src/config.rs
@@ -262,14 +262,13 @@ impl Config {
     ) -> Result<Vec<filter::Filter>> {
         let mut filters: Vec<filter::Filter> = vec![];
         for (name, c) in self.commands.iter() {
-            if c.core.typ != typ && c.core.typ != filter::FilterType::Both {
-                println!("{typ:?} != {:?}", c.core.typ);
-                continue;
-            }
             if let Some(c) = command {
                 if name != c {
                     continue;
                 }
+            }
+            if c.core.typ != typ && c.core.typ != filter::FilterType::Both {
+                continue;
             }
 
             filters.push(self.make_command(root, name, c)?);


### PR DESCRIPTION
In the case where a --command has been provided, don't attempt to add
commands to the list of filters which do not match a specified command.
