### PR TITLE
Add a top level exclude for ./vendor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,8 @@
 
 - The `dev/bin/check-go-mod.sh` script created when running `precious config init --component go` is
   now executable. Reported by Olaf Olders. GH #56.
+- The generated config for Go now excludes the `vendor` directory for all commands. Implemented by
+  Olaf Alders. GH #57.
 - As of this release there are no longer binaries built for MIPS on Linux. These targets have been
   demoted to tier 3 support by the Rust compiler.
 

--- a/precious-core/src/config_init.rs
+++ b/precious-core/src/config_init.rs
@@ -113,7 +113,7 @@ exit 0
 
 pub(crate) fn go_init() -> Init {
     Init {
-        excludes: &[],
+        excludes: &["vendor/**/*"],
         commands: &GO_COMMANDS,
         extra_files: vec![ConfigInitFile {
             path: PathBuf::from("dev/bin/check-go-mod.sh"),


### PR DESCRIPTION
to generated config when running "precious config init -c go"
