### PR TITLE
Make `perlimports` precede `perltidy` in generated config for Perl

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,5 @@
 <!-- next-header -->
 
-- Added/cleaned up some debugging output for the new `invopke.per-x-or-y` options. Fixes GH #65 and
-  #66.
-
 - Added an `--auto` flag for `precious config init`. If this is specified then `precious` will look
   at all the files in your project and generate config based on the types of files it finds.
   Suggested by John Vandenberg (@jayvdb). GH #67.
@@ -10,6 +7,15 @@
 - Fixed a bug when running `precious config init`. The `--component` argument was not required, when
   it should require at least one. If none were given it would create an empty `precious.toml` file.
   Reported by John Vandenberg (@jayvdb). GH #67.
+
+- Changed how `precious config init` generates config for Perl. The `perlimports` command is now the
+  first one in the generated config. This is necessary because `perlimports` may change the code in
+  a way that `perltidy` will then change further. Running `perlimports` after `perltidy` meant that
+  tidying Perl code could leave the code in a state where it fails linting checks. Implemented by
+  Olaf Alders (@oalders). GH #68.
+
+- Added/cleaned up some debugging output for the new `invopke.per-x-or-y` options. Fixes GH #65 and
+  #66.
 
 ## 0.7.0 - 2024-03-30
 

--- a/examples/perl/precious.toml
+++ b/examples/perl/precious.toml
@@ -19,6 +19,16 @@ exclude = [
     "xt/release/**",
 ]
 
+# Add App::perlimports as a develop phase prereq
+[commands.perlimports]
+type = "both"
+include = [ "**/*.{pl,pm,t,psgi}" ]
+cmd = [ "perlimports" ]
+lint-flags = ["--lint" ]
+tidy-flags = ["-i" ]
+ok-exit-codes = 0
+expect-stderr = true
+
 # Add Perl::Critic as a develop phase prereq
 [commands.perlcritic]
 type = "lint"
@@ -37,16 +47,6 @@ tidy-flags = [ "--backup-and-modify-in-place", "--backup-file-extension=/" ]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
 ignore-stderr = "Begin Error Output Stream"
-
-# Add App::perlimports as a develop phase prereq
-[commands.perlimports]
-type = "both"
-include = [ "**/*.{pl,pm,t,psgi}" ]
-cmd = [ "perlimports" ]
-lint-flags = ["--lint" ]
-tidy-flags = ["-i" ]
-ok-exit-codes = 0
-expect-stderr = true
 
 # Add Pod::Checker as a develop phase prereq
 [commands.podchecker]

--- a/precious-core/src/config_init.rs
+++ b/precious-core/src/config_init.rs
@@ -196,6 +196,18 @@ pub(crate) fn go_init() -> Init {
 
 const PERL_COMMANDS: [(&str, &str); 5] = [
     (
+        "perlimports",
+        r#"
+type = "both"
+include = [ "**/*.{pl,pm,t,psgi}" ]
+cmd = [ "perlimports" ]
+lint-flags = ["--lint" ]
+tidy-flags = ["-i" ]
+ok-exit-codes = 0
+expect-stderr = true
+"#,
+    ),
+    (
         "perlcritic",
         r#"
 type = "lint"
@@ -216,18 +228,6 @@ tidy-flags = [ "--backup-and-modify-in-place", "--backup-file-extension=/" ]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
 ignore-stderr = "Begin Error Output Stream"
-"#,
-    ),
-    (
-        "perlimports",
-        r#"
-type = "both"
-include = [ "**/*.{pl,pm,t,psgi}" ]
-cmd = [ "perlimports" ]
-lint-flags = ["--lint" ]
-tidy-flags = ["-i" ]
-ok-exit-codes = 0
-expect-stderr = true
 "#,
     ),
     (


### PR DESCRIPTION
The `perlimports` command might change the formatting of a page in a way that `perltidy` might later want to reformat. This PR changes the config `precious` generates for Perl so that `perlimports` runs first.
