### PR TITLE
Alias "precious fix" to "precious tidy"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 <!-- next-header -->
 
+- Added `fix` as an alias for the `tidy` command. Implemented by Michael McClimon (@mmcclimon). GH
+  #70.
 - Added `shell` and `toml` components for `precious config --component ...` options.
 
 ## 0.7.1 - 2024-05-05

--- a/precious-core/src/precious.rs
+++ b/precious-core/src/precious.rs
@@ -116,6 +116,7 @@ pub struct App {
 #[derive(Debug, Parser)]
 pub enum Subcommand {
     Lint(CommonArgs),
+    #[clap(alias = "fix")]
     Tidy(CommonArgs),
     Config(ConfigArgs),
 }

--- a/precious-integration/src/lint_tidy.rs
+++ b/precious-integration/src/lint_tidy.rs
@@ -425,6 +425,25 @@ fn all_invocation_options() -> Result<()> {
     Ok(())
 }
 
+#[test]
+#[serial]
+fn fix_is_tidy() -> Result<()> {
+    let helper = set_up_for_tests()?;
+
+    let precious = precious_path()?;
+    let env = HashMap::new();
+    exec::run(
+        &precious,
+        &["fix", "--all"],
+        &env,
+        &[0],
+        None,
+        Some(&helper.precious_root()),
+    )?;
+
+    Ok(())
+}
+
 // Since precious runs the linter in parallel on different files we to force
 // the execution to be serialized. On Linux we can use the flock command but
 // that doesn't exist on macOS so we'll use this Perl script instead.


### PR DESCRIPTION
I type "precious fix" all the time when I mean "tidy", and every time I'm annoyed. Fix this by aliasing "fix" to the tidy subcommand.