### PR TITLE
Add once-by-dir invoke mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ command.
 
 The `invoke` key tells `precious` how the command should be invoked.
 
-| Value        | Description                                                            |
-| ------------ | ---------------------------------------------------------------------- |
-| `"per-file"` | Run this command once for each matching file. **This is the default.** |
-| `"per-dir"`  | Run this command once for each matching directory.                     |
-| `"once"`     | Run this command once.                                                 |
+| Value           | Description                                                            |
+| --------------- | ---------------------------------------------------------------------- |
+| `"per-file"`    | Run this command once for each matching file. **This is the default.** |
+| `"per-dir"`     | Run this command once for each matching directory.                     |
+| `"once"`        | Run this command once with all matching files as arguments.            |
+| `"once-by-dir"` | Run this command once with all matching directories as arguments.      |
 
 There are some experimental options for the `invoke` key as well. **The exact names or the details
 of how they operate may change in a future release.**

--- a/precious-core/src/config.rs
+++ b/precious-core/src/config.rs
@@ -285,7 +285,7 @@ impl CommandConfig {
                     );
                 }
             }
-            (Invoke::Once, &WorkingDir::Dir, _) => {
+            (Invoke::Once | Invoke::OnceByDir, &WorkingDir::Dir, _) => {
                 return Err(ConfigError::CannotInvokeOnceWithWorkingDirEqDir.into());
             }
             _ => (),


### PR DESCRIPTION
Adds new batch invocation options that invoke commands once with all
matching directories as arguments, rather than invoking separately for
each dir. This is useful for tools like golangci-lint that works best
with directories and can efficiently process multiple dirs in a single
invocation.