### PR TITLE
Show a helpful message when all CLI paths are excluded

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,8 +2,10 @@
 
 - Added `python`, `typescript`, and `ruby` components to `precious config init` and to the
   `examples` directory. GH #95.
-- When given a list of paths on the CLI, `precious` will return a more helpful error when all of
-  those paths are excluded by the `precious.toml` configuration.
+- When all paths passed on the command line are excluded, precious now exits with a clearer error
+  message. In addition, it has different errors for when all paths given on the CLI are ignored
+  versus when `--all` is specified but all the paths it can find are excluded. Both exit with an
+  error status.
 - Fixed a bug where bare directory names in `exclude` patterns (e.g., `target`) did not exclude
   files inside that directory. Now `exclude = ["target"]` works exactly like a `.gitignore` entry —
   it excludes the directory and all of its contents. Previously you had to write `target/**/*` to

--- a/precious-core/src/paths/finder.rs
+++ b/precious-core/src/paths/finder.rs
@@ -34,8 +34,18 @@ pub enum FinderError {
     #[error("You cannot pass an explicit list of files when looking for {mode:}")]
     GotPathsFromCliWithWrongMode { mode: Mode },
 
-    #[error("Found some paths when looking for {mode:} but they were all excluded")]
-    AllPathsWereExcluded { mode: Mode },
+    #[error("The path given on the command line ({path}) is excluded in the precious config")]
+    CLIPathsWereExcludedSingular { path: String },
+
+    #[error(
+        "The paths given on the command line ({paths}) are all excluded in the precious config"
+    )]
+    CLIPathsWereExcludedMultiple { paths: String },
+
+    #[error(
+        "Attempted to find all matching paths but everything was excluded in the precious config"
+    )]
+    AllPathsWereExcluded,
 
     #[error("Path passed on the command line does not exist: {}", path.display())]
     NonExistentPathOnCli { path: PathBuf },
@@ -73,6 +83,8 @@ impl Finder {
         })
     }
 
+    // Fixing this will cascade through the code base. I'll do it later (maybe).
+    #[allow(clippy::needless_pass_by_value)]
     pub fn files(&mut self, cli_paths: Vec<PathBuf>) -> Result<Option<Vec1<PathBuf>>> {
         match self.mode {
             Mode::FromCli => (),
@@ -93,7 +105,7 @@ impl Finder {
         let mut files = match self.mode.clone() {
             Mode::All => self.all_files().context("Failed to get all files")?,
             Mode::FromCli => self
-                .files_from_cli(cli_paths)
+                .files_from_cli(cli_paths.clone())
                 .context("Failed to get files from command line")?,
             Mode::GitModified => self
                 .git_modified_files()
@@ -113,10 +125,19 @@ impl Finder {
                 | Mode::GitStaged
                 | Mode::GitStagedWithStash
                 | Mode::GitDiffFrom(_) => Ok(None),
-                Mode::FromCli | Mode::All => Err(FinderError::AllPathsWereExcluded {
-                    mode: self.mode.clone(),
+                Mode::FromCli => {
+                    let err = if cli_paths.len() == 1 {
+                        FinderError::CLIPathsWereExcludedSingular {
+                            path: cli_paths[0].display().to_string(),
+                        }
+                    } else {
+                        FinderError::CLIPathsWereExcludedMultiple {
+                            paths: Self::truncate_path_list(&cli_paths),
+                        }
+                    };
+                    return Err(err.into());
                 }
-                .into()),
+                Mode::All => Err(FinderError::AllPathsWereExcluded {}.into()),
             };
         }
 
@@ -374,6 +395,21 @@ impl Finder {
             })?
             .to_path_buf()
             .clean())
+    }
+
+    fn truncate_path_list(cli_paths: &[PathBuf]) -> String {
+        let is_truncated = cli_paths.len() > 3;
+        let truncated = cli_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .take(3)
+            .collect::<Vec<_>>()
+            .join(", ");
+        if is_truncated {
+            format!("{truncated}, ... and {} more", cli_paths.len() - 3)
+        } else {
+            truncated
+        }
     }
 }
 
@@ -1042,6 +1078,54 @@ mod tests {
             .unwrap();
         let cli_paths = ["main.rs", "module.rs"].iter().map(PathBuf::from).collect();
         assert_eq!(finder.files(cli_paths)?, Some(expect));
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn cli_mode_given_dir_all_excluded_singular() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        let mut finder = new_finder_with_excludes(
+            Mode::FromCli,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor/**/*".to_string()],
+        )?;
+        let res = finder.files(vec![PathBuf::from("vendor")]);
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref(),
+                Some(FinderError::CLIPathsWereExcludedSingular { .. })
+            ),
+            "expected CLIPathsWereExcludedSingular, got {err}",
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn cli_mode_given_dir_all_excluded_multiple() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        let mut finder = new_finder_with_excludes(
+            Mode::FromCli,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor/**/*".to_string()],
+        )?;
+        let res = finder.files(vec![PathBuf::from("vendor"), PathBuf::from("vendor")]);
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref(),
+                Some(FinderError::CLIPathsWereExcludedMultiple { .. })
+            ),
+            "expected CLIPathsWereExcludedSingular, got {err}",
+        );
         Ok(())
     }
 

--- a/precious-core/src/precious.rs
+++ b/precious-core/src/precious.rs
@@ -601,14 +601,22 @@ impl LintOrTidyRunner {
             | paths::mode::Mode::GitDiffFrom(_) => vec![],
         };
 
-        let files = self
+        let finder_result = self
             .finder()
             .context("Failed to create file finder")?
-            .files(cli_paths)
-            .with_context(|| format!("Failed to find files for {action}"))?;
+            .files(cli_paths);
+
+        let files = match finder_result {
+            Err(e) => return Err(e.context(format!("Failed to find files for {action}"))),
+            Ok(f) => f,
+        };
 
         match files {
-            None => Ok(Self::no_files_exit()),
+            None => Ok(Exit {
+                status: 0,
+                message: Some(String::from("No files found")),
+                error: None,
+            }),
             Some(files) => {
                 let mut all_failures: Vec<ActionFailure> = vec![];
                 for c in commands {
@@ -640,11 +648,7 @@ impl LintOrTidyRunner {
         let (status, error) = if failures.is_empty() {
             (0, None)
         } else {
-            let (red, ansi_off) = if self.color {
-                (format!("\x1B[{}m", Color::Red.to_fg_str()), "\x1B[0m")
-            } else {
-                (String::new(), "")
-            };
+            let (red, ansi_off) = self.maybe_red();
             let plural = if failures.len() > 1 { 's' } else { '\0' };
 
             let error = format!(
@@ -671,6 +675,14 @@ impl LintOrTidyRunner {
             status,
             message: None,
             error,
+        }
+    }
+
+    fn maybe_red(&self) -> (String, &str) {
+        if self.color {
+            (format!("\x1B[{}m", Color::Red.to_fg_str()), "\x1B[0m")
+        } else {
+            (String::new(), "")
         }
     }
 
@@ -858,14 +870,6 @@ impl LintOrTidyRunner {
             Ok(None)
         } else {
             Ok(Some(failures))
-        }
-    }
-
-    fn no_files_exit() -> Exit {
-        Exit {
-            status: 0,
-            message: Some(String::from("No files found")),
-            error: None,
         }
     }
 }

--- a/precious-integration/src/lint_tidy.rs
+++ b/precious-integration/src/lint_tidy.rs
@@ -292,6 +292,34 @@ fn cli_paths_in_subdir() -> Result<()> {
 
 #[test]
 #[serial]
+fn cli_paths_all_excluded() -> Result<()> {
+    let helper = set_up_for_tests()?;
+    helper.write_file("target/foo.rs", GOOD_RUST.trim_start())?;
+
+    let precious = precious_path()?;
+
+    let out = Exec::builder()
+        .exe(&precious)
+        .args(vec!["lint", "target"])
+        .ok_exit_codes(&[42])
+        .in_dir(&helper.precious_root())
+        .ignore_stderr(vec![Regex::new(".*")?])
+        .build()
+        .run()?;
+
+    let stderr = out.stderr.unwrap_or_default();
+    assert!(
+        stderr.contains(
+            "The path given on the command line (target) is excluded in the precious config"
+        ),
+        "expected excluded-paths message in stderr, got: {stderr:?}",
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn one_command() -> Result<()> {
     let helper = set_up_for_tests()?;
     let content = r#"


### PR DESCRIPTION
## Summary

Fixes #92.

When every path passed on the command line is matched by an exclude rule, precious previously returned a hard error (`Found some paths when looking for ... but they were all excluded`). This was unhelpful — the user had no indication it was safe to ignore.

This PR changes the behavior: precious now exits 0 and prints:

```
○ All paths given on the command line were excluded
```

This is distinct from the existing "No files found" message used when git modes return zero files, so the user knows specifically why nothing ran.

## Implementation

- In `precious-core/src/precious.rs`, the `FinderError::AllPathsWereExcluded` error is now caught explicitly in `run_all_commands` and converted to a clean exit with the new message, rather than propagating as an error.
- `FinderError::AllPathsWereExcluded` is retained in `finder.rs` — it remains the right signal from the finder layer.

## Tests

- **Unit test** (`precious-core/src/paths/finder.rs`): `cli_mode_given_dir_all_excluded` — verifies the finder still returns `AllPathsWereExcluded` when all CLI paths are excluded.
- **Integration test** (`precious-integration/src/lint_tidy.rs`): `cli_paths_all_excluded` — runs the binary with a fully-excluded path and asserts exit 0 and the expected message in stdout.