### PR TITLE
Add shared include/exclude lists for commands

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 ## 0.11.0 - TBD
 
+- Added support for a `[shared]` top-level config table that maps named keys to glob lists. Commands
+  can reference these keys via `shared-include` and `shared-exclude` fields to avoid duplicating
+  long lists across commands. GH #73.
 - Added `python`, `typescript`, and `ruby` components to `precious config init` and to the
   `examples` directory. GH #95.
 - When all paths passed on the command line are excluded, precious now exits with a clearer error

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ command. It's features include:
 
 - One file, `precious.toml`, defines all of your linter and tidier commands, as well as what files
   they operate on.
-- Respects VCS ignore files and allows global and per-command excludes.
+- Respects VCS ignore files and allows global, shared, and per-command includes and excludes.
 - Language-agnostic, and it works the same way with single- or multi-language projects.
 - Easy integration with commit hooks and CI systems.
 - When a command needs to be invoked multiple times with different sets of files (for example, a
@@ -110,11 +110,12 @@ project.
 Precious is configured via a single `precious.toml` or `.precious.toml` file that lives in your
 project root. The file is in [TOML format](https://github.com/toml-lang/toml).
 
-There is just one key that can be set in the top level table of the config file:
+The following keys can be set in the top level table of the config file:
 
-| Key       | Type             | Required? | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------- | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `exclude` | array of strings | no        | Each array member is a pattern that will be matched against potential files when `precious` is run. These patterns are matched in the same way as patterns in a [gitignore file](https://git-scm.com/docs/gitignore#_pattern_format). <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ excluded even if it matches previous rules. |
+| Key        | Type                          | Required? | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------- | ----------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `exclude`  | array of strings              | no        | Each array member is a pattern that will be matched against potential files when `precious` is run. These patterns are matched in the same way as patterns in a [gitignore file](https://git-scm.com/docs/gitignore#_pattern_format). <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ excluded even if it matches previous rules. |
+| `[shared]` | table of string → string list | no        | A table mapping named keys to lists of glob patterns. These can be referenced by name in per-command `shared-include` and `shared-exclude` keys to avoid repeating the same glob lists across multiple commands. See [Shared Include/Exclude Lists](#shared-includeexclude-lists) below.                                                                                                                                 |
 
 All other configuration is on a per-command basis. A command is something that either tidies (aka
 pretty prints or beautifies), lints, or does both. These commands are external programs which
@@ -249,20 +250,22 @@ of every possible set of options.
 
 The other keys allowed for each command are as follows:
 
-| Key                       | Type                         | Required? | Applies To               | Default | Description                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------- | ---------------------------- | --------- | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                    | string                       | **yes**   | all                      |         | This must be either `lint`, `tidy`, or `both`. This defines what type of command this is. A command which is `both` **must** also define `lint-flags`, `tidy-flags` or both of these.                                                                                                                                                                     |
-| `include`                 | string or array of strings   | **yes**   | all                      |         | Each array member is a [gitignore pattern](https://git-scm.com/docs/gitignore#_pattern_format) that tells `precious` what files this command applies to. <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ included even if it matches previous rules.               |
-| `exclude`                 | string or array of strings   | no        | all                      |         | Each array member is a [gitignore pattern](https://git-scm.com/docs/gitignore#_pattern_format) that tells `precious` what files this command should not be applied to. <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ excluded even if it matches previous rules. |
-| `cmd`                     | string or array of strings   | **yes**   | all                      |         | This is the executable to be run followed by any arguments that should always be passed.                                                                                                                                                                                                                                                                  |
-| `env`                     | table - values are strings   | no        | all                      |         | This key allows you to set one or more environment variables that will be set when the command is run. The values in this table must be strings.                                                                                                                                                                                                          |
-| `path-flag`               | string                       | no        | all                      |         | By default, `precious` will pass the path being operated on to the command it executes as the final, positional, argument(s). If the command takes paths via a flag you need to specify that flag with this key.                                                                                                                                          |
-| `lint-flags`              | string or array of strings   | no        | combined linter & tidier |         | If a command is both a linter and tidier then it may take extra flags to operate in linting mode. This is how you set that flag.                                                                                                                                                                                                                          |
-| `tidy-flags`              | string or array of strings   | no        | combined linter & tidier |         | If a command is both a linter and tidier then it may take extra flags to operate in tidying mode. This is how you set that flag.                                                                                                                                                                                                                          |
-| `ok-exit-codes`           | integer or array of integers | **yes**   | all                      |         | Any exit code that **does not** indicate an abnormal exit should be here. For most commands this is just `0`, but some commands may use other exit codes even for a normal exit.                                                                                                                                                                          |
-| `lint-failure-exit-codes` | integer or array of integers | no        | linters                  |         | If the command is a linter then these are the status codes that indicate a lint failure. These need to be specified so `precious` can distinguish an exit because of a lint failure versus an exit because of some unexpected issue.                                                                                                                      |
-| `ignore-stderr`           | string or array of strings   | all       | all                      |         | By default, `precious` assumes that when a command sends output to `stderr` that indicates a failure to lint or tidy. This parameter can specify one or more regexes. These regexes will be matched against the command's stderr output. If _any_ of the regexes match, the stderr output is ignored.                                                     |
-| `labels`                  | string or array of strings   | all       | all                      |         | One or more labels used to categorize commands. See below for more details.                                                                                                                                                                                                                                                                               |
+| Key                       | Type                         | Required?                           | Applies To               | Default | Description                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------- | ---------------------------- | ----------------------------------- | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                    | string                       | **yes**                             | all                      |         | This must be either `lint`, `tidy`, or `both`. This defines what type of command this is. A command which is `both` **must** also define `lint-flags`, `tidy-flags` or both of these.                                                                                                                                                                     |
+| `include`                 | string or array of strings   | yes, unless `shared-include` is set | all                      |         | Each array member is a [gitignore pattern](https://git-scm.com/docs/gitignore#_pattern_format) that tells `precious` what files this command applies to. <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ included even if it matches previous rules.               |
+| `shared-include`          | string or array of strings   | yes, unless `include` is set        | all                      |         | One or more keys from the top-level `[shared]` table. The glob lists for each key are prepended to this command's `include` list. See [Shared Include/Exclude Lists](#shared-includeexclude-lists) below.                                                                                                                                                 |
+| `exclude`                 | string or array of strings   | no                                  | all                      |         | Each array member is a [gitignore pattern](https://git-scm.com/docs/gitignore#_pattern_format) that tells `precious` what files this command should not be applied to. <br> You can use lines starting with a `!` to negate the meaning of previous rules in the list, so that anything that matches is _not_ excluded even if it matches previous rules. |
+| `shared-exclude`          | string or array of strings   | no                                  | all                      |         | One or more keys from the top-level `[shared]` table. The glob lists for each key are prepended to this command's `exclude` list. See [Shared Include/Exclude Lists](#shared-includeexclude-lists) below.                                                                                                                                                 |
+| `cmd`                     | string or array of strings   | **yes**                             | all                      |         | This is the executable to be run followed by any arguments that should always be passed.                                                                                                                                                                                                                                                                  |
+| `env`                     | table - values are strings   | no                                  | all                      |         | This key allows you to set one or more environment variables that will be set when the command is run. The values in this table must be strings.                                                                                                                                                                                                          |
+| `path-flag`               | string                       | no                                  | all                      |         | By default, `precious` will pass the path being operated on to the command it executes as the final, positional, argument(s). If the command takes paths via a flag you need to specify that flag with this key.                                                                                                                                          |
+| `lint-flags`              | string or array of strings   | no                                  | combined linter & tidier |         | If a command is both a linter and tidier then it may take extra flags to operate in linting mode. This is how you set that flag.                                                                                                                                                                                                                          |
+| `tidy-flags`              | string or array of strings   | no                                  | combined linter & tidier |         | If a command is both a linter and tidier then it may take extra flags to operate in tidying mode. This is how you set that flag.                                                                                                                                                                                                                          |
+| `ok-exit-codes`           | integer or array of integers | **yes**                             | all                      |         | Any exit code that **does not** indicate an abnormal exit should be here. For most commands this is just `0`, but some commands may use other exit codes even for a normal exit.                                                                                                                                                                          |
+| `lint-failure-exit-codes` | integer or array of integers | no                                  | linters                  |         | If the command is a linter then these are the status codes that indicate a lint failure. These need to be specified so `precious` can distinguish an exit because of a lint failure versus an exit because of some unexpected issue.                                                                                                                      |
+| `ignore-stderr`           | string or array of strings   | all                                 | all                      |         | By default, `precious` assumes that when a command sends output to `stderr` that indicates a failure to lint or tidy. This parameter can specify one or more regexes. These regexes will be matched against the command's stderr output. If _any_ of the regexes match, the stderr output is ignored.                                                     |
+| `labels`                  | string or array of strings   | all                                 | all                      |         | One or more labels used to categorize commands. See below for more details.                                                                                                                                                                                                                                                                               |
 
 ### Referencing the Project Root
 
@@ -555,6 +558,43 @@ lint-failure-exit-codes = [1]
 
 Simply run `precious lint -s` in your hook. It will exit with a non-zero status if any of the lint
 commands indicate a linting problem.
+
+### Shared Include/Exclude Lists
+
+If several commands operate on the same set of files, you can avoid repeating glob lists by defining
+named glob lists in a top-level `[shared]` table and referencing them via `shared-include` and
+`shared-exclude`.
+
+```toml
+[shared]
+js = ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+generated = ["src/generated/**/*", "vendor/**/*"]
+
+[commands.prettier]
+type = "both"
+shared-include = "js"
+shared-exclude = "generated"
+cmd = ["prettier", "--write"]
+ok-exit-codes = 0
+lint-flags = "--check"
+lint-failure-exit-codes = 1
+
+[commands.eslint]
+type = "lint"
+shared-include = "js"
+shared-exclude = "generated"
+exclude = ["**/*.test.ts"]
+cmd = ["eslint"]
+ok-exit-codes = 0
+lint-failure-exit-codes = 1
+```
+
+- `shared-include` and `shared-exclude` each accept a single key name (string) or an array of key
+  names. Multiple keys are concatenated in the order given.
+- Shared globs are prepended _before_ any per-command `include` or `exclude` globs.
+- Every key referenced must exist in `[shared]`, otherwise `precious` will exit with an error.
+- A command must define at least one of `include` or `shared-include`, otherwise `precious` will
+  exit with an error.
 
 ### You want to run commands in a specific order
 

--- a/examples/perl/precious.toml
+++ b/examples/perl/precious.toml
@@ -19,10 +19,15 @@ exclude = [
     "xt/release/**",
 ]
 
+# Shared glob lists referenced by multiple commands below.
+[shared]
+perl-code = ["**/*.{pl,pm,t,psgi}"]
+perl-docs = ["**/*.{pl,pm,pod}"]
+
 # Add App::perlimports as a develop phase prereq
 [commands.perlimports]
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perlimports"]
 lint-flags = ["--lint"]
 tidy-flags = ["-i"]
@@ -32,7 +37,7 @@ expect-stderr = true
 # Add Perl::Critic as a develop phase prereq
 [commands.perlcritic]
 type = "lint"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perlcritic", "--profile=$PRECIOUS_ROOT/perlcriticrc"]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
@@ -40,7 +45,7 @@ lint-failure-exit-codes = 2
 # Add Perl::Tidy as a develop phase prereq
 [commands.perltidy]
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perltidy", "--profile=$PRECIOUS-ROOT/perltidyrc"]
 lint-flags = ["--assert-tidy", "--no-standard-output", "--outfile=/dev/null"]
 tidy-flags = ["--backup-and-modify-in-place", "--backup-file-extension=/"]
@@ -51,7 +56,7 @@ ignore-stderr = "Begin Error Output Stream"
 # Add Pod::Checker as a develop phase prereq
 [commands.podchecker]
 type = "lint"
-include = ["**/*.{pl,pm,pod}"]
+shared-include = "perl-docs"
 cmd = ["podchecker", "--warnings", "--warnings"]
 ok-exit-codes = [0, 2]
 lint-failure-exit-codes = 1
@@ -60,7 +65,7 @@ ignore-stderr = [".+ pod syntax OK", ".+ does not contain any pod commands"]
 # Add Pod::Tidy as a develop phase prereq
 [commands.podtidy]
 type = "tidy"
-include = ["**/*.{pl,pm,pod}"]
+shared-include = "perl-docs"
 cmd = ["podtidy", "--columns", "80", "--inplace", "--nobackup"]
 ok-exit-codes = 0
 lint-failure-exit-codes = 1

--- a/examples/typescript/precious.toml
+++ b/examples/typescript/precious.toml
@@ -1,11 +1,14 @@
 exclude = ["build/**", "dist/**", "node_modules/**"]
 
+# Shared glob list used by both commands below.
+[shared]
+ts-and-js = ["**/*.{ts,tsx,js,jsx}"]
+
 # eslint and prettier are installed as devDependencies; the ./node_modules/.bin/
 # prefix uses the local install rather than a globally installed version.
-# The include pattern covers both TypeScript and JavaScript files.
 [commands.eslint]
 type = "both"
-include = ["**/*.{ts,tsx,js,jsx}"]
+shared-include = "ts-and-js"
 cmd = ["./node_modules/.bin/eslint"]
 tidy-flags = "--fix"
 ok-exit-codes = 0
@@ -15,7 +18,7 @@ lint-failure-exit-codes = 1
 # complement each other and are typically used together.
 [commands.prettier-typescript]
 type = "both"
-include = ["**/*.{ts,tsx,js,jsx}"]
+shared-include = "ts-and-js"
 cmd = ["./node_modules/.bin/prettier"]
 lint-flags = "--check"
 tidy-flags = "--write"

--- a/precious-core/src/config.rs
+++ b/precious-core/src/config.rs
@@ -14,10 +14,22 @@ use thiserror::Error;
 pub struct CommandConfig {
     #[serde(rename = "type")]
     pub(crate) typ: CommandType,
-    #[serde(deserialize_with = "string_or_seq_string")]
+    #[serde(default, deserialize_with = "string_or_seq_string")]
     pub(crate) include: Vec<String>,
     #[serde(default, deserialize_with = "string_or_seq_string")]
     pub(crate) exclude: Vec<String>,
+    #[serde(
+        default,
+        alias = "shared-include",
+        deserialize_with = "string_or_seq_string"
+    )]
+    pub(crate) shared_include: Vec<String>,
+    #[serde(
+        default,
+        alias = "shared-exclude",
+        deserialize_with = "string_or_seq_string"
+    )]
+    pub(crate) shared_exclude: Vec<String>,
     #[serde(default)]
     pub(crate) invoke: Option<Invoke>,
     #[serde(default, alias = "working-dir", deserialize_with = "working_dir")]
@@ -66,6 +78,8 @@ pub struct CommandConfig {
 pub struct Config {
     #[serde(default, deserialize_with = "string_or_seq_string")]
     pub(crate) exclude: Vec<String>,
+    #[serde(default)]
+    shared: HashMap<String, Vec<String>>,
     commands: IndexMap<String, CommandConfig>,
 }
 
@@ -79,6 +93,10 @@ pub(crate) enum ConfigError {
     CannotInvokePerDirInRootWithPathArgs { path_args: PathArgs },
     #[error(r#"Cannot set invoke = "once" and working-dir = "dir""#)]
     CannotInvokeOnceWithWorkingDirEqDir,
+    #[error("Command \"{command}\" references unknown shared key \"{key}\"")]
+    UnknownSharedKey { command: String, key: String },
+    #[error("Command \"{command}\" does not define an \"include\" or \"shared-include\"")]
+    NoInclude { command: String },
     #[error(transparent)]
     Toml(#[from] toml::de::Error),
 }
@@ -202,7 +220,20 @@ impl Config {
         typ: CommandType,
     ) -> Result<Vec<command::Command>> {
         let mut commands: Vec<command::Command> = vec![];
-        for (name, c) in self.commands {
+        for (name, mut c) in self.commands {
+            c.include.splice(
+                0..0,
+                Self::resolve_shared_keys(&c.shared_include, &self.shared, &name)?,
+            );
+            c.exclude.splice(
+                0..0,
+                Self::resolve_shared_keys(&c.shared_exclude, &self.shared, &name)?,
+            );
+
+            if c.include.is_empty() {
+                return Err(ConfigError::NoInclude { command: name }.into());
+            }
+
             if let Some(c) = command {
                 if name != c {
                     continue;
@@ -224,6 +255,28 @@ impl Config {
         Ok(commands)
     }
 
+    fn resolve_shared_keys(
+        keys: &[String],
+        shared: &HashMap<String, Vec<String>>,
+        command: &str,
+    ) -> Result<Vec<String>> {
+        let mut result = Vec::new();
+        for key in keys {
+            match shared.get(key) {
+                Some(globs) => result.extend_from_slice(globs),
+                None => {
+                    return Err(ConfigError::UnknownSharedKey {
+                        command: command.to_string(),
+                        key: key.clone(),
+                    }
+                    .into())
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    // Note: returns raw CommandConfig values; shared_include/shared_exclude are not resolved.
     pub(crate) fn command_info(self) -> Vec<(String, CommandConfig)> {
         self.commands.into_iter().collect()
     }
@@ -310,8 +363,10 @@ impl CommandConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mitsein::prelude::*;
     use pretty_assertions::assert_eq;
     use serial_test::parallel;
+    use std::path::Path;
     use test_case::test_case;
 
     #[test]
@@ -520,6 +575,8 @@ mod tests {
             path_args: Some(path_args),
             include: vec![String::from("**/*.rs")],
             exclude: vec![],
+            shared_include: vec![],
+            shared_exclude: vec![],
             cmd: vec![String::from("some-linter")],
             env: Default::default(),
             lint_flags: vec![],
@@ -559,6 +616,8 @@ mod tests {
             path_args: None,
             include: vec![String::from("**/*.rs")],
             exclude: vec![],
+            shared_include: vec![],
+            shared_exclude: vec![],
             cmd: vec![String::from("some-linter")],
             env: Default::default(),
             lint_flags: vec![],
@@ -612,6 +671,341 @@ mod tests {
 
         let config: Config = toml::from_str(&toml_text)?;
         assert_eq!(config.commands[0].invoke, Some(expect));
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_include_single_key() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            js = ["**/*.js", "**/*.jsx"]
+
+            [commands.prettier]
+            type = "lint"
+            shared-include = "js"
+            cmd = ["prettier", "--check"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        assert_eq!(commands.len(), 1);
+
+        let files: Vec1<PathBuf> = vec1![
+            PathBuf::from("src/foo.js"),
+            PathBuf::from("src/bar.jsx"),
+            PathBuf::from("src/baz.rs"),
+        ];
+        let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
+        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        included.sort();
+        assert_eq!(
+            included,
+            vec![Path::new("src/bar.jsx"), Path::new("src/foo.js")]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_include_multiple_keys() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            js = ["**/*.js"]
+            styles = ["**/*.css", "**/*.scss"]
+
+            [commands.prettier]
+            type = "lint"
+            shared-include = ["js", "styles"]
+            cmd = ["prettier", "--check"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        assert_eq!(commands.len(), 1);
+
+        let files: Vec1<PathBuf> = vec1![
+            PathBuf::from("src/app.js"),
+            PathBuf::from("src/main.css"),
+            PathBuf::from("src/theme.scss"),
+            PathBuf::from("src/main.rs"),
+        ];
+        let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
+        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        included.sort();
+        assert_eq!(
+            included,
+            vec![
+                Path::new("src/app.js"),
+                Path::new("src/main.css"),
+                Path::new("src/theme.scss"),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_exclude() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            generated = ["vendor/**/*", "generated/**/*"]
+
+            [commands.eslint]
+            type = "lint"
+            include = "**/*.js"
+            shared-exclude = "generated"
+            cmd = ["eslint"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        assert_eq!(commands.len(), 1);
+
+        let files: Vec1<PathBuf> = vec1![
+            PathBuf::from("src/app.js"),
+            PathBuf::from("vendor/lib.js"),
+            PathBuf::from("generated/out.js"),
+        ];
+        let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
+        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        included.sort();
+        assert_eq!(included, vec![Path::new("src/app.js")]);
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_mixed_with_per_command() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            js = ["**/*.js"]
+            generated = ["vendor/**/*"]
+
+            [commands.eslint]
+            type = "lint"
+            shared-include = "js"
+            include = ["**/*.ts"]
+            shared-exclude = "generated"
+            exclude = ["**/*.test.ts"]
+            cmd = ["eslint"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        assert_eq!(commands.len(), 1);
+
+        let files: Vec1<PathBuf> = vec1![
+            PathBuf::from("src/app.js"),
+            PathBuf::from("src/app.ts"),
+            PathBuf::from("src/app.test.ts"),
+            PathBuf::from("vendor/lib.js"),
+        ];
+        let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
+        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        included.sort();
+        assert_eq!(
+            included,
+            vec![Path::new("src/app.js"), Path::new("src/app.ts")]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_unknown_key() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            js = ["**/*.js"]
+
+            [commands.prettier]
+            type = "lint"
+            shared-include = "typescript"
+            cmd = ["prettier", "--check"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let err = config
+            .into_lint_commands(Path::new("."), None, None)
+            .unwrap_err()
+            .downcast::<ConfigError>()?;
+        assert_eq!(
+            err,
+            ConfigError::UnknownSharedKey {
+                command: "prettier".to_string(),
+                key: "typescript".to_string(),
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn no_include_or_shared_include() -> Result<()> {
+        let toml_text = r#"
+            [commands.prettier]
+            type = "lint"
+            cmd = ["prettier", "--check"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let err = config
+            .into_lint_commands(Path::new("."), None, None)
+            .unwrap_err()
+            .downcast::<ConfigError>()?;
+        assert_eq!(
+            err,
+            ConfigError::NoInclude {
+                command: "prettier".to_string(),
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn shared_include_only() -> Result<()> {
+        let toml_text = r#"
+            [shared]
+            rs = ["**/*.rs"]
+
+            [commands.rustfmt]
+            type = "lint"
+            shared-include = "rs"
+            cmd = ["rustfmt", "--check"]
+            ok-exit-codes = 0
+            lint-failure-exit-codes = 1
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        assert_eq!(commands.len(), 1);
+
+        let files: Vec1<PathBuf> = vec1![
+            PathBuf::from("src/lib.rs"),
+            PathBuf::from("src/main.rs"),
+            PathBuf::from("src/main.js"),
+        ];
+        let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
+        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        included.sort();
+        assert_eq!(
+            included,
+            vec![Path::new("src/lib.rs"), Path::new("src/main.rs")]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn no_include_on_non_matching_command_is_still_an_error() -> Result<()> {
+        // A command with no include should be caught even when --command
+        // selects a different command — validation runs before the name filter.
+        let toml_text = r#"
+            [commands.rustfmt]
+            type = "lint"
+            cmd = ["rustfmt", "--check"]
+            ok-exit-codes = 0
+
+            [commands.clippy]
+            type = "lint"
+            include = "**/*.rs"
+            cmd = ["clippy"]
+            ok-exit-codes = 0
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let err = config
+            .into_lint_commands(Path::new("."), Some("clippy"), None)
+            .unwrap_err()
+            .downcast::<ConfigError>()?;
+        assert_eq!(
+            err,
+            ConfigError::NoInclude {
+                command: "rustfmt".to_string(),
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn no_include_on_non_matching_label_is_still_an_error() -> Result<()> {
+        // A command with no include should be caught even when a label filter
+        // would exclude it — validation runs before the label filter.
+        let toml_text = r#"
+            [commands.rustfmt]
+            type = "lint"
+            cmd = ["rustfmt", "--check"]
+            ok-exit-codes = 0
+
+            [commands.clippy]
+            type = "lint"
+            include = "**/*.rs"
+            labels = ["ci"]
+            cmd = ["clippy"]
+            ok-exit-codes = 0
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let err = config
+            .into_lint_commands(Path::new("."), None, Some("ci"))
+            .unwrap_err()
+            .downcast::<ConfigError>()?;
+        assert_eq!(
+            err,
+            ConfigError::NoInclude {
+                command: "rustfmt".to_string(),
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn no_include_on_non_matching_type_is_still_an_error() -> Result<()> {
+        // A tidy-only command with no include should be caught even when
+        // calling into_lint_commands — validation runs before the type filter.
+        let toml_text = r#"
+            [commands.rustfmt]
+            type = "tidy"
+            cmd = ["rustfmt"]
+            ok-exit-codes = 0
+        "#;
+
+        let config: Config = toml::from_str(toml_text)?;
+        let err = config
+            .into_lint_commands(Path::new("."), None, None)
+            .unwrap_err()
+            .downcast::<ConfigError>()?;
+        assert_eq!(
+            err,
+            ConfigError::NoInclude {
+                command: "rustfmt".to_string(),
+            }
+        );
 
         Ok(())
     }

--- a/precious-core/src/config_init.rs
+++ b/precious-core/src/config_init.rs
@@ -17,6 +17,7 @@ use std::os::unix::fs::PermissionsExt;
 
 pub(crate) struct Init {
     pub(crate) excludes: &'static [&'static str],
+    pub(crate) shared: &'static [(&'static str, &'static [&'static str])],
     pub(crate) commands: &'static [(&'static str, &'static str)],
     pub(crate) extra_files: Vec<ConfigInitFile>,
     pub(crate) tool_urls: &'static [&'static str],
@@ -217,6 +218,7 @@ exit 0
 pub(crate) fn go_init() -> Init {
     Init {
         excludes: &["vendor/**/*"],
+        shared: &[],
         commands: &GO_COMMANDS,
         extra_files: vec![
             ConfigInitFile {
@@ -237,12 +239,17 @@ pub(crate) fn go_init() -> Init {
     }
 }
 
+const PERL_SHARED: [(&str, &[&str]); 2] = [
+    ("perl-code", &["**/*.{pl,pm,t,psgi}"]),
+    ("perl-docs", &["**/*.{pl,pm,pod}"]),
+];
+
 const PERL_COMMANDS: [(&str, &str); 5] = [
     (
         "perlimports",
         r#"
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perlimports"]
 lint-flags = ["--lint"]
 tidy-flags = ["-i"]
@@ -254,7 +261,7 @@ expect-stderr = true
         "perlcritic",
         r#"
 type = "lint"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perlcritic", "--profile=$PRECIOUS_ROOT/perlcriticrc"]
 ok-exit-codes = 0
 lint-failure-exit-codes = 2
@@ -264,7 +271,7 @@ lint-failure-exit-codes = 2
         "perltidy",
         r#"
 type = "both"
-include = ["**/*.{pl,pm,t,psgi}"]
+shared-include = "perl-code"
 cmd = ["perltidy", "--profile=$PRECIOUS_ROOT/perltidyrc"]
 lint-flags = ["--assert-tidy", "--no-standard-output", "--outfile=/dev/null"]
 tidy-flags = ["--backup-and-modify-in-place", "--backup-file-extension=/"]
@@ -277,7 +284,7 @@ ignore-stderr = "Begin Error Output Stream"
         "podchecker",
         r#"
 type = "lint"
-include = ["**/*.{pl,pm,pod}"]
+shared-include = "perl-docs"
 cmd = ["podchecker", "--warnings", "--warnings"]
 ok-exit-codes = [0, 2]
 lint-failure-exit-codes = 1
@@ -288,7 +295,7 @@ ignore-stderr = [".+ pod syntax OK", ".+ does not contain any pod commands"]
         "podtidy",
         r#"
 type = "tidy"
-include = ["**/*.{pl,pm,pod}"]
+shared-include = "perl-docs"
 cmd = ["podtidy", "--columns", "100", "--inplace", "--nobackup"]
 ok-exit-codes = 0
 lint-failure-exit-codes = 1
@@ -299,6 +306,7 @@ lint-failure-exit-codes = 1
 pub(crate) fn perl_init() -> Init {
     Init {
         excludes: &[".build/**", "blib/**"],
+        shared: &PERL_SHARED,
         commands: &PERL_COMMANDS,
         extra_files: vec![],
         tool_urls: &[
@@ -351,6 +359,7 @@ lint-failure-exit-codes = 1
 pub(crate) fn python_init() -> Init {
     Init {
         excludes: &[".venv/**", "**/__pycache__/**", "dist/**", "build/**"],
+        shared: &[],
         commands: &PYTHON_COMMANDS,
         extra_files: vec![],
         tool_urls: &[
@@ -360,12 +369,14 @@ pub(crate) fn python_init() -> Init {
     }
 }
 
+const TYPESCRIPT_SHARED: [(&str, &[&str]); 1] = [("ts-and-js", &["**/*.{ts,tsx,js,jsx}"])];
+
 const TYPESCRIPT_COMMANDS: [(&str, &str); 2] = [
     (
         "eslint",
         r#"
 type = "both"
-include = ["**/*.{ts,tsx,js,jsx}"]
+shared-include = "ts-and-js"
 cmd = ["./node_modules/.bin/eslint"]
 tidy-flags = "--fix"
 ok-exit-codes = 0
@@ -376,7 +387,7 @@ lint-failure-exit-codes = 1
         "prettier-typescript",
         r#"
 type = "both"
-include = ["**/*.{ts,tsx,js,jsx}"]
+shared-include = "ts-and-js"
 cmd = ["./node_modules/.bin/prettier"]
 lint-flags = "--check"
 tidy-flags = "--write"
@@ -390,6 +401,7 @@ ignore-stderr = ["Code style issues"]
 pub(crate) fn typescript_init() -> Init {
     Init {
         excludes: &["node_modules/**", "dist/**", "build/**"],
+        shared: &TYPESCRIPT_SHARED,
         commands: &TYPESCRIPT_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://eslint.org/", "https://prettier.io/"],
@@ -413,6 +425,7 @@ lint-failure-exit-codes = 1
 pub(crate) fn ruby_init() -> Init {
     Init {
         excludes: &[".bundle/**", "vendor/bundle/**"],
+        shared: &[],
         commands: &RUBY_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://rubocop.org/"],
@@ -459,6 +472,7 @@ ignore-stderr = ["Checking.+precious", "Finished.+dev", "could not compile"]
 pub(crate) fn rust_init() -> Init {
     Init {
         excludes: &["target"],
+        shared: &[],
         commands: &RUST_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://doc.rust-lang.org/clippy/"],
@@ -493,6 +507,7 @@ lint_failure_exit_codes = 1
 pub(crate) fn shell_init() -> Init {
     Init {
         excludes: &["target"],
+        shared: &[],
         commands: &SHELL_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://www.shellcheck.net/", "https://github.com/mvdan/sh"],
@@ -516,6 +531,7 @@ ignore-stderr = ["The .+ file is not sorted", "The .+ file is not unique"]
 pub(crate) fn gitignore_init() -> Init {
     Init {
         excludes: &[],
+        shared: &[],
         commands: &GITIGNORE_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://github.com/houseabsolute/omegasort"],
@@ -546,6 +562,7 @@ ignore-stderr = ["Code style issues"]
 pub(crate) fn markdown_init() -> Init {
     Init {
         excludes: &[],
+        shared: &[],
         commands: &MARKDOWN_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://prettier.io/"],
@@ -568,6 +585,7 @@ ignore_stderr = "INFO taplo.+"
 pub(crate) fn toml_init() -> Init {
     Init {
         excludes: &[],
+        shared: &[],
         commands: &TOML_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://taplo.tamasfe.dev/"],
@@ -591,6 +609,7 @@ ignore-stderr = ["Code style issues"]
 pub(crate) fn yaml_init() -> Init {
     Init {
         excludes: &[],
+        shared: &[],
         commands: &YAML_COMMANDS,
         extra_files: vec![],
         tool_urls: &["https://prettier.io/"],
@@ -599,6 +618,7 @@ pub(crate) fn yaml_init() -> Init {
 
 struct ConfigElements {
     excludes: HashSet<&'static str>,
+    shared: IndexMap<&'static str, &'static [&'static str]>,
     commands: IndexMap<&'static str, &'static str>,
     extra_files: HashMap<PathBuf, ConfigInitFile>,
     tool_urls: IndexSet<&'static str>,
@@ -624,6 +644,12 @@ pub(crate) fn write_config_files(
 
     if !toml.is_empty() {
         toml.push_str("\n\n");
+    }
+
+    let shared = shared_toml(&elements.shared);
+    if !shared.is_empty() {
+        toml.push_str(&shared);
+        toml.push('\n');
     }
 
     toml.push_str(&commands_toml(elements.commands));
@@ -652,6 +678,7 @@ pub(crate) fn write_config_files(
 
 fn config_elements(auto: bool, components: &[InitComponent]) -> Result<ConfigElements> {
     let mut excludes: HashSet<&'static str> = HashSet::new();
+    let mut shared: IndexMap<&'static str, &'static [&'static str]> = IndexMap::new();
     let mut commands = IndexMap::new();
     let mut extra_files = HashMap::new();
     let mut tool_urls: IndexSet<&'static str> = IndexSet::new();
@@ -671,6 +698,9 @@ fn config_elements(auto: bool, components: &[InitComponent]) -> Result<ConfigEle
             InitComponent::Yaml => yaml_init(),
         };
         excludes.extend(init.excludes);
+        for (key, globs) in init.shared {
+            shared.insert(key, globs);
+        }
         for (name, c) in init.commands {
             commands.insert(*name, *c);
         }
@@ -682,6 +712,7 @@ fn config_elements(auto: bool, components: &[InitComponent]) -> Result<ConfigEle
 
     Ok(ConfigElements {
         excludes,
+        shared,
         commands,
         extra_files,
         tool_urls,
@@ -763,6 +794,24 @@ fn excludes_toml(excludes: &HashSet<&str>) -> String {
                 .join("\n")
         )
     }
+}
+
+fn shared_toml(shared: &IndexMap<&str, &[&str]>) -> String {
+    use std::fmt::Write;
+
+    if shared.is_empty() {
+        return String::new();
+    }
+    let mut lines = String::from("[shared]\n");
+    for (key, globs) in shared {
+        let globs_str = globs
+            .iter()
+            .map(|g| format!(r#""{g}""#))
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(lines, "{key} = [{globs_str}]").expect("this should never return an error");
+    }
+    lines
 }
 
 fn commands_toml(commands: IndexMap<&str, &str>) -> String {


### PR DESCRIPTION
## Summary

- Adds a `[shared]` top-level config table that maps named keys to glob lists
- Commands can reference these keys via `shared-include` and `shared-exclude` fields instead of duplicating long glob lists
- References an unknown shared key or omitting both `include` and `shared-include` is a hard config error

## Test plan

- [ ] 7 new unit tests in `precious-core/src/config.rs` covering single-key, multi-key, exclude, mixed shared+per-command, unknown key error, no-include error, and shared-include-only configs
- [ ] All 178 existing tests continue to pass
- [ ] Linting clean (`mise exec -- precious lint --all`)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)