### PR TITLE
Fix exclude patterns to match directory contents like gitignore

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 ## 0.10.3 - TBD
 
 - Added `python`, `typescript`, and `ruby` components to `precious config init`. GH #95.
+- Fixed a bug where bare directory names in `exclude` patterns (e.g., `target`) did not exclude
+  files inside that directory. Now `exclude = ["target"]` works exactly like a `.gitignore` entry —
+  it excludes the directory and all of its contents. Previously you had to write `target/**/*` to
+  get this behavior; that form still works and is equivalent.
 
 ## 0.10.2 2026-01-25
 

--- a/README.md
+++ b/README.md
@@ -551,6 +551,26 @@ ok-exit-codes = [0]
 lint-failure-exit-codes = [1]
 ```
 
+### You were previously using `dir/**/*` to exclude a directory's contents
+
+In older versions of `precious`, bare directory names like `target` in an `exclude` list did not
+actually exclude files _inside_ that directory — only the exact path `target` itself. This was a
+bug. It is now fixed: `"target"` works exactly like a `.gitignore` entry and excludes the directory
+and all its contents.
+
+If you were using `"target/**/*"` as a workaround, you can simplify it to just `"target"`. Both
+forms are now equivalent.
+
+There is no supported way to restore the old (broken) behavior. If you need fine-grained control
+over which files inside a directory are excluded, use negation patterns:
+
+```toml
+exclude = [
+    "target",
+    "!target/some/important/file.rs",
+]
+```
+
 ### You want to run Precious as a commit hook
 
 Simply run `precious lint -s` in your hook. It will exit with a non-zero status if any of the lint

--- a/precious-core/src/paths/finder.rs
+++ b/precious-core/src/paths/finder.rs
@@ -501,6 +501,21 @@ mod tests {
 
     #[test]
     #[parallel]
+    fn all_mode_with_excluded_files_bare_dir() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        let mut finder = new_finder_with_excludes(
+            Mode::All,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor".to_string()],
+        )?;
+        assert_eq!(finder.files(vec![])?, Some(helper.all_files1()));
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
     fn git_modified_mode_empty() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let mut finder = new_finder(Mode::GitModified, helper.precious_root())?;
@@ -564,6 +579,26 @@ mod tests {
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
+        )?;
+        assert_eq!(finder.files(vec![])?, Some(modified));
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn git_modified_mode_with_excluded_files_bare_dir() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.stage_all()?;
+        helper.commit_all()?;
+
+        let modified = Vec1::try_from(helper.modify_files()?).unwrap();
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        let mut finder = new_finder_with_excludes(
+            Mode::GitModified,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor".to_string()],
         )?;
         assert_eq!(finder.files(vec![])?, Some(modified));
         Ok(())
@@ -702,6 +737,23 @@ mod tests {
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
+        )?;
+        assert_eq!(finder.files(vec![])?, Some(modified));
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn git_staged_mode_with_excluded_files_bare_dir() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        let modified = Vec1::try_from(helper.modify_files()?).unwrap();
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.stage_all()?;
+        let mut finder = new_finder_with_excludes(
+            Mode::GitStaged,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor".to_string()],
         )?;
         assert_eq!(finder.files(vec![])?, Some(modified));
         Ok(())
@@ -897,6 +949,24 @@ mod tests {
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
+        )?;
+        assert_eq!(
+            finder.files(vec![PathBuf::from(".")])?,
+            Some(helper.all_files1()),
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn cli_mode_given_dir_with_excluded_files_bare_dir() -> Result<()> {
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        let mut finder = new_finder_with_excludes(
+            Mode::FromCli,
+            helper.precious_root(),
+            helper.precious_root(),
+            vec!["vendor".to_string()],
         )?;
         assert_eq!(
             finder.files(vec![PathBuf::from(".")])?,

--- a/precious-core/src/paths/matcher.rs
+++ b/precious-core/src/paths/matcher.rs
@@ -42,7 +42,9 @@ pub struct Matcher {
 
 impl Matcher {
     pub fn path_matches(&self, path: &Path, is_dir: bool) -> bool {
-        self.gitignore.matched(path, is_dir).is_ignore()
+        self.gitignore
+            .matched_path_or_any_parents(path, is_dir)
+            .is_ignore()
     }
 }
 
@@ -92,6 +94,18 @@ mod tests {
                 globs: &["/foo/**/*", "!/foo/bar/baz.*"],
                 yes: &["/foo/file.go", "/foo/bar/quux/file.go"],
                 no: &["/bar/file.go", "/foo/bar/baz.txt"],
+            },
+            // Bare directory names should match files inside that directory,
+            // just like gitignore does.
+            TestSet {
+                globs: &["target"],
+                yes: &["target", "target/file.rs", "target/debug/build/foo/bar.rs"],
+                no: &["src/main.rs", "nottarget/file.rs"],
+            },
+            TestSet {
+                globs: &["target", "!target/important.rs"],
+                yes: &["target/file.rs", "target/debug/build/foo.rs"],
+                no: &["src/main.rs", "target/important.rs"],
             },
         ];
 


### PR DESCRIPTION
## Summary

- Fixes a bug where bare directory names in `exclude` patterns (e.g., `target`) did not exclude files inside that directory
- The one-line fix switches from `Gitignore::matched` to `Gitignore::matched_path_or_any_parents` in the `ignore` crate, which walks up the path's ancestor components to check for a match — exactly what gitignore does during directory traversal
- `"target"` and `"target/**/*"` are now equivalent; the README already documented the intended behavior, so this is a pure bug fix

## Test plan

- [ ] New `TestSet` in `matcher.rs` verifies that `target` matches `target/file.rs` and `target/debug/build/foo/bar.rs`, and that negation (`!target/important.rs`) still works
- [ ] Four new `_bare_dir` test variants in `finder.rs` cover all modes (All, GitModified, GitStaged, FromCli) using `"vendor"` instead of `"vendor/**/*"`
- [ ] All 183 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)