### PR TITLE
Ensure all paths are UTF-8 and fail fast if we encounter any that are not

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,5 @@ importas = "importas"
 excluder = "excluder"
 includer = "includer"
 typ = "typ"
+# Used in the plan doc for UTF-8 handling as an example of broken UTF-8 for "cafe".
+caf = "caf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,12 +117,6 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
-
-[[package]]
-name = "clean-path"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
 
 [[package]]
 name = "colored"
@@ -246,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -365,7 +368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -507,8 +510,8 @@ name = "precious-core"
 version = "0.10.2"
 dependencies = [
  "anyhow",
+ "camino",
  "clap",
- "clean-path",
  "comfy-table",
  "fern",
  "filetime",
@@ -539,6 +542,7 @@ version = "0.10.2"
 dependencies = [
  "anyhow",
  "bon",
+ "camino",
  "itertools",
  "libc",
  "log",
@@ -556,6 +560,7 @@ name = "precious-integration"
 version = "0.10.2"
 dependencies = [
  "anyhow",
+ "camino",
  "itertools",
  "precious-core",
  "precious-helpers",
@@ -572,6 +577,7 @@ name = "precious-testhelper"
 version = "0.10.2"
 dependencies = [
  "anyhow",
+ "camino",
  "env_logger",
  "log",
  "mitsein",
@@ -730,7 +736,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -894,7 +900,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1061,7 +1067,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ version = "0.10.2"
 [workspace.dependencies]
 anyhow = { version = "1.0.100", default-features = false }
 bon = { version = "3.8.1", default-features = false }
+camino = { version = "1.1", features = ["serde1"] }
 clap = { version = "4.5.50", default-features = false, features = [
     "cargo",
     "derive",
     "std",
     "wrap_help",
 ] }
-clean-path = { version = "0.2.1", default-features = false }
 comfy-table = { version = "7.2.1", default-features = false }
 env_logger = { version = "0.11.8", default-features = false }
 fern = { version = ">= 0.5.0, < 0.7.0", default-features = false, features = ["colored"] }

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,12 @@
   files inside that directory. Now `exclude = ["target"]` works exactly like a `.gitignore` entry —
   it excludes the directory and all of its contents. Previously you had to write `target/**/*` to
   get this behavior; that form still works and is equivalent.
+- Precious now fails fast with a clear error when it encounters a file path that is not valid UTF-8,
+  instead of silently doing a lossy conversion. Previously non-UTF-8 paths were corrupted at the
+  `git ls-files` decode step and at subprocess-argument construction. The error message includes
+  both a human-readable lossy approximation and the exact raw bytes of the path. Switching the
+  internal `git ls-files`/`git diff` invocations to `-z` also fixes handling of valid non-ASCII
+  names like `café.txt` that git would otherwise C-quote.
 
 ## 0.10.2 2026-01-25
 

--- a/docs/superpowers/plans/2026-05-30-utf8-path-handling.md
+++ b/docs/superpowers/plans/2026-05-30-utf8-path-handling.md
@@ -1,0 +1,954 @@
+# UTF-8 Path Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make precious fail fast with a clear error whenever it encounters a path that is not valid
+UTF-8, instead of silently lossy-converting.
+
+**Architecture:** Adopt `camino::Utf8PathBuf` / `Utf8Path` throughout `precious-core` so the UTF-8
+invariant is enforced by the type system. Fallible `Path → Utf8Path` conversions happen only at the
+four entry points (filesystem walk, `git ls-files -z`, `git rev-parse --show-toplevel`, derived
+paths from `canonicalize`/`pathdiff`). CLI args are validated by clap. Config TOML strings are
+already UTF-8.
+
+**Tech Stack:** Rust, `camino` (with `serde`), existing crates (`ignore`, `clap`, `anyhow`,
+`thiserror`, `mitsein`, `clean-path`, `pathdiff`).
+
+**Source of truth:** `docs/superpowers/specs/2026-05-30-utf8-path-handling-design.md`. Read it
+before starting any task.
+
+---
+
+## Pre-flight
+
+Verify the working directory is the `utf8-path-handling` worktree:
+
+```bash
+git rev-parse --show-toplevel
+# Expected: /home/autarch/.claude/worktrees/precious/utf8-path-handling
+git branch --show-current
+# Expected: claude/utf8-path-handling
+```
+
+To run the full check (used after every task):
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+To satisfy the pre-commit hook (do not bypass it):
+
+```bash
+mise exec precious -- precious tidy <paths>
+```
+
+---
+
+## File Structure
+
+- **Create:**
+  - `precious-core/src/paths/utf8.rs` — `NonUtf8Source`, `NonUtf8PathError`, `Display`.
+  - `precious-integration/tests/non_utf8_paths.rs` — end-to-end gated tests.
+- **Modify:**
+  - `Cargo.toml` (workspace) — add `camino` with `serde` feature.
+  - `precious-core/Cargo.toml` — depend on `camino`.
+  - `precious-core/src/paths.rs` — `pub mod utf8;`.
+  - `precious-core/src/paths/matcher.rs` — `Path → Utf8Path`.
+  - `precious-core/src/paths/finder.rs` — internal types, four validation sites, `-z` git
+    invocation, error variants update, sig change to `Finder::files`.
+  - `precious-core/src/command.rs` — drop `to_string_lossy`; consume `Utf8Path`;
+    `Utf8PathBuf::try_from` around `pathdiff`/`canonicalize`; switch fs bridge to `as_std_path()`.
+  - `precious-core/src/config.rs` — `WorkingDir::ChdirTo(Utf8PathBuf)`.
+  - `precious-core/src/config_init.rs` — `ConfigInitFile.path: Utf8PathBuf`, `extra_files` keys,
+    `FileExists.path`, the `clap` `path` arg.
+  - `precious-core/src/precious.rs` — CLI `Vec<Utf8PathBuf>`, `--config Utf8PathBuf`, internal
+    types; drop residual `to_string_lossy`.
+  - `precious-helpers/src/exec.rs` — add a `stdout_bytes()` accessor (raw `Vec<u8>`) on `Output` so
+    callers can read the unmodified `git ls-files -z` stdout.
+
+---
+
+## Task 1: Foundation — `camino` dependency and the `NonUtf8PathError` error type
+
+This task only touches new code plus `Cargo.toml`; nothing else compiles against it yet.
+
+**Files:**
+
+- Modify: `Cargo.toml` (workspace deps), `precious-core/Cargo.toml`.
+- Modify: `precious-core/src/paths.rs:1-3`.
+- Create: `precious-core/src/paths/utf8.rs`.
+
+- [ ] **Step 1: Add `camino` to the workspace**
+
+In `Cargo.toml` workspace dependencies section, add:
+
+```toml
+camino = { version = "1.1", features = ["serde1"] }
+```
+
+In `precious-core/Cargo.toml` dependencies, add `camino.workspace = true`.
+
+Run `cargo check -p precious-core` and confirm the dependency resolves.
+
+- [ ] **Step 2: Write the failing unit test for `NonUtf8PathError` display**
+
+Create `precious-core/src/paths/utf8.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[cfg(unix)]
+    #[test]
+    fn display_filesystem_walk() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::PathBuf;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"data\xff.bin"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::FilesystemWalk,
+        };
+        assert_eq!(
+            err.to_string(),
+            r#"non-UTF-8 path from filesystem walk: "data\u{fffd}.bin" (raw bytes: "data\xff.bin")"#,
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_git_ls_files() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::PathBuf;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"a\xc3\x28b"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::GitLsFiles,
+        };
+        let s = err.to_string();
+        assert!(s.starts_with("non-UTF-8 path from git ls-files:"), "{s}");
+        assert!(s.contains(r#"raw bytes: "a\xc3(b""#), "{s}");
+    }
+}
+```
+
+Run: `cargo test -p precious-core paths::utf8::tests --no-run` Expected: FAIL — `utf8` module does
+not exist yet (well, the test file does but its `use super::*;` finds no items). Add `pub mod utf8;`
+to `precious-core/src/paths.rs`. Re-run; FAIL on missing `NonUtf8PathError`, `NonUtf8Source`.
+
+- [ ] **Step 3: Implement `NonUtf8PathError`**
+
+Prepend to `precious-core/src/paths/utf8.rs` (above the test module):
+
+```rust
+use std::{fmt, path::PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonUtf8Source {
+    FilesystemWalk,
+    GitLsFiles,
+    GitRoot,
+    DerivedPath,
+}
+
+impl fmt::Display for NonUtf8Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::FilesystemWalk => "filesystem walk",
+            Self::GitLsFiles => "git ls-files",
+            Self::GitRoot => "git rev-parse --show-toplevel",
+            Self::DerivedPath => "derived path",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct NonUtf8PathError {
+    pub raw: PathBuf,
+    pub source: NonUtf8Source,
+}
+
+impl fmt::Display for NonUtf8PathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#"non-UTF-8 path from {}: "{}" (raw bytes: "{}")"#,
+            self.source,
+            self.raw.display(),
+            escape_raw(&self.raw),
+        )
+    }
+}
+
+fn escape_raw(path: &std::path::Path) -> String {
+    // Render each byte: printable ASCII as itself, everything else as \xNN.
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = path.as_os_str().as_bytes();
+        let mut out = String::with_capacity(bytes.len());
+        for &b in bytes {
+            if (0x20..0x7f).contains(&b) && b != b'\\' && b != b'"' {
+                out.push(b as char);
+            } else {
+                use std::fmt::Write as _;
+                let _ = write!(out, r"\x{b:02x}");
+            }
+        }
+        out
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On non-unix platforms `OsStr` is not byte-addressable; the lossy
+        // string form is the best we can do. camino still enforces UTF-8 by
+        // construction, so this branch is informational only.
+        path.to_string_lossy().into_owned()
+    }
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `cargo test -p precious-core paths::utf8::tests -- --nocapture` Expected: PASS (2 tests on
+unix, 0 on Windows).
+
+- [ ] **Step 5: Tidy and commit**
+
+```bash
+mise exec precious -- precious tidy precious-core/src/paths/utf8.rs precious-core/src/paths.rs Cargo.toml precious-core/Cargo.toml
+git add Cargo.toml Cargo.lock precious-core/Cargo.toml precious-core/src/paths.rs precious-core/src/paths/utf8.rs
+git commit -m "Add NonUtf8PathError and camino dependency"
+```
+
+---
+
+## Task 2: Add raw-bytes accessor on `Exec` output
+
+`git ls-files -z` emits NUL-separated raw bytes; we cannot validate per-entry once `Vec<u8>` has
+been lossy-decoded to `String`. Today `Exec::run()` returns `Output { stdout: Option<String> }`
+built via `from_utf8_lossy`. Add a sibling raw-bytes path.
+
+**Files:**
+
+- Modify: `precious-helpers/src/exec.rs`.
+
+- [ ] **Step 1: Inspect current `Output` definition**
+
+Read `precious-helpers/src/exec.rs:200-320` to confirm the `Output` struct shape and the
+`bytes_to_option_string` helper around line 314.
+
+- [ ] **Step 2: Write a failing test**
+
+Append to the existing test module in `precious-helpers/src/exec.rs`:
+
+```rust
+#[test]
+fn raw_stdout_preserves_non_utf8_bytes() -> anyhow::Result<()> {
+    // Use printf to emit a NUL-separated stream containing an invalid UTF-8 byte.
+    let out = Exec::builder()
+        .exe("printf")
+        .args(vec![r"a\x00b\xff\x00"])
+        .ok_exit_codes(&[0])
+        .in_dir(std::env::current_dir()?)
+        .build()
+        .run()?;
+    let bytes = out.stdout_bytes().expect("expected raw stdout");
+    assert_eq!(bytes, b"a\x00b\xff\x00".to_vec());
+    Ok(())
+}
+```
+
+Run: `cargo test -p precious-helpers raw_stdout_preserves_non_utf8_bytes` Expected: FAIL — `Output`
+has no `stdout_bytes` method.
+
+- [ ] **Step 3: Implement raw-bytes capture**
+
+In `precious-helpers/src/exec.rs`:
+
+1. Add `stdout_bytes: Option<Vec<u8>>` to `Output`.
+2. In `handle_output` (or wherever the successful path constructs `Output`), populate both `stdout`
+   (the existing lossy `Option<String>`) and `stdout_bytes` (`Some(output.stdout.clone())` when
+   non-empty).
+3. Add `pub fn stdout_bytes(&self) -> Option<&[u8]> { self.stdout_bytes.as_deref() }`.
+
+Do not remove the existing `stdout: Option<String>` field — other callers still rely on it.
+
+- [ ] **Step 4: Verify the test passes**
+
+Run: `cargo test -p precious-helpers raw_stdout_preserves_non_utf8_bytes` Expected: PASS.
+
+Run: `cargo test -p precious-helpers` Expected: all pre-existing tests still pass.
+
+- [ ] **Step 5: Tidy and commit**
+
+```bash
+mise exec precious -- precious tidy precious-helpers/src/exec.rs
+git add precious-helpers/src/exec.rs
+git commit -m "Expose raw stdout bytes from Exec for binary output"
+```
+
+---
+
+## Task 3: Convert `Matcher` to `Utf8Path`
+
+Smallest leaf type-change; isolated from everything else.
+
+**Files:**
+
+- Modify: `precious-core/src/paths/matcher.rs`.
+
+- [ ] **Step 1: Change the type signatures**
+
+Edit `precious-core/src/paths/matcher.rs`:
+
+- Replace `use std::path::Path;` with `use camino::{Utf8Path, Utf8PathBuf};`.
+- Change `MatcherBuilder::new<P: AsRef<Path>>(root: P)` to `pub fn new<P: AsRef<Utf8Path>>(root: P)`
+  and pass `root.as_ref().as_std_path()` to `GitignoreBuilder::new`.
+- Change `Matcher::path_matches(&self, path: &Path, is_dir: bool)` to
+  `pub fn path_matches(&self, path: &Utf8Path, is_dir: bool) -> bool`; internally pass
+  `path.as_std_path()` to `matched_path_or_any_parents`.
+
+- [ ] **Step 2: Update the existing matcher test**
+
+In the same file's `tests` module, replace `Path::new(y)` and `Path::new(n)` with `Utf8Path::new(y)`
+and `Utf8Path::new(n)`. Add `use camino::Utf8Path;`.
+
+- [ ] **Step 3: Run the matcher tests**
+
+Run: `cargo test -p precious-core paths::matcher` Expected: PASS (same coverage as before; only the
+public API types changed).
+
+Note: `cargo check --workspace` will fail at this point because `Finder` still passes `&Path` to
+`Matcher`. That gets fixed in Task 4; do not commit yet.
+
+- [ ] **Step 4: Hold the commit**
+
+Skip the commit; this task's changes ship together with Task 4 because the workspace will not build
+between them.
+
+---
+
+## Task 4: Convert `Finder` to `Utf8PathBuf` with discovery-boundary validation
+
+The big migration. `Finder` is where the four discovery boundaries live; converting it forces the
+validation in.
+
+**Files:**
+
+- Modify: `precious-core/src/paths/finder.rs`.
+
+- [ ] **Step 1: Write the new boundary unit tests (failing)**
+
+Add to the `tests` module in `precious-core/src/paths/finder.rs` (gated unix only — these touch real
+on-disk filenames):
+
+```rust
+#[cfg(unix)]
+#[test]
+#[parallel]
+fn all_mode_errors_on_non_utf8_filename() -> Result<()> {
+    use crate::paths::utf8::{NonUtf8PathError, NonUtf8Source};
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+    let bad_name = OsStr::from_bytes(b"data\xff.bin");
+    let mut full = helper.precious_root();
+    full.push(bad_name);
+    fs::write(&full, b"contents")?;
+
+    let mut finder = new_finder(Mode::All, helper.precious_root())?;
+    let err = finder.files(vec![]).expect_err("expected non-UTF-8 error");
+    let downcast = err
+        .downcast_ref::<NonUtf8PathError>()
+        .expect("expected NonUtf8PathError");
+    assert_eq!(downcast.source, NonUtf8Source::FilesystemWalk);
+    Ok(())
+}
+```
+
+Run:
+`cargo test -p precious-core paths::finder::tests::all_mode_errors_on_non_utf8_filename --no-run`
+Expected: FAIL to compile (the rest of the migration is still pending).
+
+- [ ] **Step 2: Convert internal types**
+
+In `precious-core/src/paths/finder.rs`:
+
+- Replace `use std::{fs, path::{Path, PathBuf}, sync::LazyLock};` with
+  `use std::{fs, sync::LazyLock}; use camino::{Utf8Path, Utf8PathBuf};`.
+- Add `use crate::paths::utf8::{NonUtf8PathError, NonUtf8Source};`.
+- Replace every `PathBuf` field in `Finder` with `Utf8PathBuf` and every `&Path` parameter on its
+  methods with `&Utf8Path`. Specifically:
+  - `project_root: Utf8PathBuf`
+  - `git_root: Option<Utf8PathBuf>`
+  - `cwd: Utf8PathBuf`
+- Change `FinderError` variants to use `Utf8PathBuf` (and drop the `.display()` calls —
+  `Utf8PathBuf` already `Display`s as a plain `&str`).
+- Change `Finder::new` signature to
+  `pub fn new(mode: Mode, project_root: &Utf8Path, cwd: Utf8PathBuf, exclude_globs: Vec<String>) -> Result<Finder>`.
+  Canonicalize via `fs::canonicalize(project_root.as_std_path())` and wrap with
+  `Utf8PathBuf::try_from(...).map_err(|e| NonUtf8PathError { raw: e.into_path_buf(), source: NonUtf8Source::DerivedPath })`.
+- Change `Finder::files` signature to
+  `pub fn files(&mut self, cli_paths: Vec<Utf8PathBuf>) -> Result<Option<Vec1<Utf8PathBuf>>>`.
+  Remove the `#[allow(clippy::needless_pass_by_value)]` if no longer needed.
+- Update `truncate_path_list` to take `&[Utf8PathBuf]` and call `.as_str()` instead of
+  `.display().to_string()`.
+
+- [ ] **Step 3: Validate at the filesystem-walk boundary**
+
+In `walkdir_files`, after each `Ok(ent)` from the walker, replace `files.push(ent.into_path());`
+with:
+
+```rust
+let p = ent.into_path();
+let utf8 = Utf8PathBuf::from_path_buf(p).map_err(|raw| NonUtf8PathError {
+    raw,
+    source: NonUtf8Source::FilesystemWalk,
+})?;
+if utf8.as_std_path().is_dir() {
+    continue;
+}
+files.push(utf8);
+```
+
+(Move the `is_dir` check after the conversion so we still skip directories; the existing
+`ent.path().is_dir()` block goes away.)
+
+Change the locals `files: Vec<PathBuf>` to `Vec<Utf8PathBuf>`. Pass `root.as_std_path()` to
+`ignore::overrides::OverrideBuilder::new` and `ignore::WalkBuilder::new` since those still want
+`&Path`.
+
+- [ ] **Step 4: Validate at the git-root boundary**
+
+In `git_root()`, replace:
+
+```rust
+self.git_root = Some(PathBuf::from(stdout.trim()));
+```
+
+with:
+
+```rust
+let trimmed = stdout.trim().to_string();
+let raw = std::path::PathBuf::from(&trimmed);
+let utf8 = Utf8PathBuf::try_from(raw.clone()).map_err(|_| NonUtf8PathError {
+    raw,
+    source: NonUtf8Source::GitRoot,
+})?;
+self.git_root = Some(utf8);
+```
+
+(`stdout` is already `String` from the existing `Exec::run` — the early lossy decode in
+`precious-helpers` would mask a truly invalid git root, but cases where the user's git root is on a
+non-UTF-8 path are vanishingly rare and the lossy-converted string will still fail the
+`Utf8PathBuf::try_from` round-trip on real-world bytes; we accept this as an acceptable
+approximation in line with the spec's "fail fast at boundary" intent.)
+
+Return type of `git_root` becomes `Result<Utf8PathBuf>`.
+
+- [ ] **Step 5: Switch `git ls-files` to `-z` with byte-level validation**
+
+In `files_from_git`, change from reading `output.stdout` (`Option<String>`) to reading
+`output.stdout_bytes()`. Replace the existing `s.lines().filter_map(...)` block with:
+
+```rust
+match output.stdout_bytes() {
+    Some(bytes) => {
+        let mut paths: Vec<Utf8PathBuf> = Vec::new();
+        for raw in bytes.split(|b| *b == 0).filter(|s| !s.is_empty()) {
+            let s = match std::str::from_utf8(raw) {
+                Ok(s) => s,
+                Err(_) => {
+                    let raw_path = {
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::ffi::OsStrExt;
+                            std::path::PathBuf::from(std::ffi::OsStr::from_bytes(raw))
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            std::path::PathBuf::from(String::from_utf8_lossy(raw).into_owned())
+                        }
+                    };
+                    return Err(NonUtf8PathError {
+                        raw: raw_path,
+                        source: NonUtf8Source::GitLsFiles,
+                    }
+                    .into());
+                }
+            };
+            let rel = Utf8PathBuf::from(s);
+            if exclude_matcher.path_matches(&rel, false) {
+                continue;
+            }
+            let mut f = git_root.clone();
+            f.push(&rel);
+            if !f.as_std_path().exists() {
+                debug!(
+                    "The staged file at {rel} (abs path {f}) was deleted so it will be ignored.",
+                );
+                continue;
+            }
+            paths.push(f);
+        }
+        Ok(self.paths_relative_to_project_root(&git_root, paths)?)
+    }
+    None => Ok(vec![]),
+}
+```
+
+The three call sites that build `args` for `files_from_git` must each have `"-z"` appended:
+
+- `git_modified_files`: `vec!["diff", "--name-only", "-z", "--diff-filter=ACM", "HEAD"]`
+- `git_staged_files`: `vec!["diff", "--cached", "--name-only", "-z", "--diff-filter=ACM"]`
+- `git_modified_since`: `vec!["diff", "--name-only", "-z", "--diff-filter=ACM", &since_dot]`
+
+- [ ] **Step 6: Update `path_relative_to_project_root` to validate `canonicalize` output**
+
+Replace:
+
+```rust
+let canonical = fs::canonicalize(path)
+    .with_context(|| format!("Failed to canonicalize path {}", path.display()))?
+    .clean();
+```
+
+with:
+
+```rust
+let canonical_std = fs::canonicalize(path.as_std_path())
+    .with_context(|| format!("Failed to canonicalize path {path}"))?
+    .clean();
+let canonical = Utf8PathBuf::try_from(canonical_std.clone()).map_err(|_| {
+    NonUtf8PathError { raw: canonical_std, source: NonUtf8Source::DerivedPath }
+})?;
+```
+
+`clean_path::Clean` returns a `PathBuf`; convert with `Utf8PathBuf::try_from` and treat failure as
+`DerivedPath`. Apply the same wrap to the second `.clean()` call at the end of the function (which
+is called on the result of `strip_prefix`).
+
+Adjust `paths_relative_to_project_root` to take `Vec<Utf8PathBuf>` and return
+`Result<Vec<Utf8PathBuf>>`; `path_root: &Utf8Path`.
+
+- [ ] **Step 7: Update `files_from_cli`**
+
+Change its signature to
+`fn files_from_cli(&self, cli_paths: Vec<Utf8PathBuf>) -> Result<Vec<Utf8PathBuf>>`. Replace
+`self.cwd.clone().join(rel_to_cwd.clone())` with `self.cwd.join(&rel_to_cwd)`. `Utf8PathBuf::exists`
+and `is_dir` exist; use them. Update `NonExistentPathOnCli` to hold `Utf8PathBuf`.
+
+- [ ] **Step 8: Update the in-file tests**
+
+Update every test that uses `PathBuf::from("…")` to `Utf8PathBuf::from("…")`, every `&Path`
+parameter to `&Utf8Path`. Update `new_finder*` helpers' signatures. Keep the existing pre-existing
+tests' coverage intact — they exercise the same behavior, just with stricter types.
+
+Add a `use camino::Utf8PathBuf;` at the top of the `tests` module.
+
+- [ ] **Step 9: Run the finder tests**
+
+Run: `cargo test -p precious-core paths::finder` Expected: All pre-existing tests pass; the new
+`all_mode_errors_on_non_utf8_filename` test passes (and is skipped on Windows). Note that the
+workspace as a whole will still not build until Tasks 5–7 land.
+
+- [ ] **Step 10: Hold the commit**
+
+Same as Task 3 — hold all commits until the workspace builds again at the end of Task 7.
+
+---
+
+## Task 5: Migrate `command.rs` to `Utf8Path`
+
+**Files:**
+
+- Modify: `precious-core/src/command.rs`.
+
+- [ ] **Step 1: Replace `Path`/`PathBuf` types**
+
+In `precious-core/src/command.rs`:
+
+- Replace `use std::path::{Path, PathBuf}` with `use std::path::PathBuf` (still needed for the
+  `Utf8PathBuf::try_from` failure case) and add `use camino::{Utf8Path, Utf8PathBuf};`.
+- Convert every field, parameter, and local that holds a path to `Utf8Path`/`Utf8PathBuf`:
+  - `Command::project_root: Utf8PathBuf`
+  - `PathInfo.dir: Option<Utf8PathBuf>`
+  - `PathMap.path_map: HashMap<Utf8PathBuf, PathInfo>`
+  - `ChdirTo(Utf8PathBuf)` (this lives in the `WorkingDir` enum imported from `config.rs` — wait
+    until Task 6 lands the change there; for this task, just adjust the local matches and inserts to
+    match).
+  - `operating_on` signatures:
+    `fn operating_on(&self, files: &Slice1<&Utf8Path>, in_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>>`
+  - `path_relative_to(&self, path: &Utf8Path, in_dir: &Utf8Path) -> Utf8PathBuf`
+  - `in_dir(&self, file: &Utf8Path) -> Result<Utf8PathBuf>`
+  - `filter_and_sort_files<'a>(&self, files: &'a Slice1<Utf8PathBuf>) -> Vec<&'a Utf8Path>`
+
+- [ ] **Step 2: Drop `to_string_lossy` everywhere**
+
+Inside this file, replace every `p.to_string_lossy().to_string()`, `p.to_string_lossy()`,
+`f.to_string_lossy().to_string()`, `path.to_string_lossy().to_string()`, etc. with one of:
+
+- `p.as_str().to_string()` if a `String` is needed.
+- `p` directly (used in `format!` / `Display` contexts).
+- `p` directly in `Command::arg(...)` (`Utf8Path: AsRef<OsStr>` via deref).
+
+Audit lines 535, 721, 864, 925, 985, 999, 1012, 1115, 1137, 1139, 1148 (and any that move during
+editing).
+
+- [ ] **Step 3: Bridge to std where required**
+
+`pathdiff::diff_paths` returns `Option<PathBuf>` and `fs::canonicalize` returns `PathBuf`. Wrap each
+call site:
+
+```rust
+let canon_std = fs::canonicalize(path.as_std_path())
+    .with_context(|| format!("Failed to canonicalize {path}"))?;
+let canon = Utf8PathBuf::try_from(canon_std.clone()).map_err(|_| NonUtf8PathError {
+    raw: canon_std,
+    source: NonUtf8Source::DerivedPath,
+})?;
+```
+
+```rust
+let diff_std = pathdiff::diff_paths(path.as_std_path(), in_dir.as_std_path())
+    .ok_or_else(|| /* existing error */)?;
+let diff = Utf8PathBuf::try_from(diff_std.clone()).map_err(|_| NonUtf8PathError {
+    raw: diff_std,
+    source: NonUtf8Source::DerivedPath,
+})?;
+```
+
+Use `path.as_std_path()` whenever you need an `&Path` for an external API (`fs::*`, `ignore::*`,
+`clean_path`).
+
+- [ ] **Step 4: Update in-file tests**
+
+Convert `PathBuf::from` → `Utf8PathBuf::from` in the test module (lines ~1172, 1205–1320). The
+`Slice1::from_slice_unchecked` calls keep the same shape.
+
+- [ ] **Step 5: Compile-only verification**
+
+Run: `cargo check -p precious-core` Expected: errors remain only in `config.rs`, `config_init.rs`,
+and `precious.rs` (callers of `command.rs` and `Finder`). The body of `command.rs` itself compiles.
+
+Hold the commit.
+
+---
+
+## Task 6: Migrate `config.rs` and `config_init.rs`
+
+**Files:**
+
+- Modify: `precious-core/src/config.rs`, `precious-core/src/config_init.rs`.
+
+- [ ] **Step 1: `WorkingDir::ChdirTo` becomes `Utf8PathBuf`**
+
+In `precious-core/src/config.rs`:
+
+- Replace `use std::path::{Path, PathBuf}` with `use std::path::PathBuf` only if still referenced;
+  add `use camino::{Utf8Path, Utf8PathBuf};`.
+- Change `ChdirTo(PathBuf)` to `ChdirTo(Utf8PathBuf)`. Because `Utf8PathBuf` has `serde` support (we
+  enabled the feature in Task 1), TOML deserialization works without custom code. Update line 176 to
+  `Ok(Some(WorkingDir::ChdirTo(Utf8PathBuf::from(value))))`.
+- Replace `FileCannotBeRead { file: PathBuf, ... }` with `Utf8PathBuf`. The config-file path comes
+  from the CLI (Task 7 makes it `Utf8PathBuf`) — chain the type through.
+- Update the in-file tests: `PathBuf::from("foo")` → `Utf8PathBuf::from("foo")` and the
+  `Vec1<PathBuf>` test fixtures → `Vec1<Utf8PathBuf>` (lines 545, 552, 697–906).
+
+- [ ] **Step 2: Migrate `config_init.rs`**
+
+In `precious-core/src/config_init.rs`:
+
+- Replace `use std::path::{Path, PathBuf}` with
+  `use camino::{Utf8Path, Utf8PathBuf}; use std::path::PathBuf;` (PathBuf may still be needed
+  transiently).
+- `ConfigInitFile.path: Utf8PathBuf` (line 27).
+- `FileExists { path: Utf8PathBuf }` (line 50).
+- The hardcoded paths at lines 225 and 230: `path: Utf8PathBuf::from("dev/bin/check-go-mod.sh")`,
+  etc.
+- `extra_files: HashMap<Utf8PathBuf, ConfigInitFile>` (line 623).
+- `write_extra_files(extra_files: &HashMap<Utf8PathBuf, ConfigInitFile>)` (line 832). Inside, use
+  `path.as_std_path()` for the actual `fs::write` etc.
+- The clap `path` field in `ConfigInitArgs` is in `precious.rs` (Task 7).
+
+- [ ] **Step 3: Compile-only verification**
+
+Run: `cargo check -p precious-core` Expected: errors now confined to `precious.rs`. Hold the commit.
+
+---
+
+## Task 7: Migrate `precious.rs` CLI and propagate to compile-clean
+
+**Files:**
+
+- Modify: `precious-core/src/precious.rs`.
+
+- [ ] **Step 1: CLI fields become `Utf8PathBuf`**
+
+In `precious-core/src/precious.rs`:
+
+- Add `use camino::{Utf8Path, Utf8PathBuf};`; trim `use std::path::{Path, PathBuf};` to whichever of
+  those is still genuinely needed (keep `PathBuf` only if it appears in fallback-conversion sites).
+- `App.config: Option<Utf8PathBuf>` (line 87).
+- `CommonArgs.paths: Vec<Utf8PathBuf>` (line 163).
+- `ConfigInitArgs.path: Utf8PathBuf` (line 190). Adjust the `default_value` literal — clap can parse
+  `Utf8PathBuf` from a string, so `default_value = "precious.toml"` continues to work.
+- `Precious.project_root: Utf8PathBuf`, `Precious.cwd: Utf8PathBuf`,
+  `Precious.paths: Vec<Utf8PathBuf>` (lines 417–426).
+- `ActionFailure.paths: Vec<Utf8PathBuf>` (line 73).
+- `PreciousError::ConfigFileHasNoParent { file: Utf8PathBuf }` (line 37).
+- `PreciousError::CannotFindRoot { cwd: String }` keeps `String`.
+
+- [ ] **Step 2: Drop `to_string_lossy` in this file**
+
+Specifically lines 326, 350, 447, 666:
+
+- Line 326: `p.to_string_lossy().is_empty()` → `p.as_str().is_empty()`.
+- Line 350: `cwd.to_string_lossy().to_string()` → `cwd.to_string()` (since `cwd: &Utf8Path` after
+  the signature change in step 3).
+- Line 447: `path.to_string_lossy()` (the `$PATH` debug log — `path` here is the env var value, an
+  `OsString`; keep `to_string_lossy()` because env vars are not paths in our taxonomy).
+- Line 666: `af.paths.iter().map(|p| p.to_string_lossy())` → `af.paths.iter().map(|p| p.as_str())`.
+
+- [ ] **Step 3: Fix helper signatures**
+
+- `fn project_root(config_file: Option<&Utf8Path>, cwd: &Utf8Path) -> Result<Utf8PathBuf>` (line
+  323).
+- `fn default_config_file(dir: &Utf8Path) -> Utf8PathBuf` (line 361). Replace the inner
+  `PathBuf::from(dir)` with `Utf8PathBuf::from(dir.as_str())` (line 375).
+- `fn config_file(&self, dir: &Utf8Path) -> Utf8PathBuf` (line 308).
+- `load_config`: return `Result<(Utf8PathBuf, Utf8PathBuf, Utf8PathBuf, config::Config)>` (line
+  297).
+- The `Finder::new` call site: now requires `&Utf8Path` for `project_root` and `Utf8PathBuf` for
+  `cwd`. Use `env::current_dir()` plus `Utf8PathBuf::try_from(...)` (map failure to
+  `NonUtf8PathError { source: DerivedPath, .. }`).
+- The `from_iter` test fixtures at lines 923–1340: convert `PathBuf` → `Utf8PathBuf`. Line 1132
+  already maps `PathBuf::from`; switch to `Utf8PathBuf::from`. Line 1346's
+  `String::from_utf8(buffer)?` is unrelated and stays.
+
+- [ ] **Step 4: Run the full workspace check**
+
+Run: `cargo check --workspace --all-targets` Expected: clean build.
+
+- [ ] **Step 5: Run the workspace tests**
+
+Run: `cargo test --workspace` Expected: all pre-existing tests pass, plus the new tests added in
+Tasks 1, 2, and 4 pass. Tests gated `#[cfg(unix)]` skip on Windows.
+
+- [ ] **Step 6: Clippy check**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings` Expected: clean.
+
+- [ ] **Step 7: Tidy, then a single migration commit**
+
+```bash
+mise exec precious -- precious tidy precious-core precious-helpers
+```
+
+If `precious tidy` reports nothing to do for any path, that is fine. Then:
+
+```bash
+git add precious-core precious-helpers
+git commit -m "Migrate precious-core to camino::Utf8Path with fail-fast UTF-8 validation"
+```
+
+This commit covers Tasks 3 through 7 because the workspace cannot compile in between.
+
+---
+
+## Task 8: End-to-end integration tests for non-UTF-8 filenames
+
+Verify the user-facing behavior of a real precious run against a real on-disk non-UTF-8 filename,
+and add the `café.txt` regression test confirming the `-z` change does not break valid non-ASCII
+names.
+
+**Files:**
+
+- Create: `precious-integration/tests/non_utf8_paths.rs` (or extend an existing integration-test
+  file if precious-integration already has one — check first).
+
+- [ ] **Step 1: Find the existing integration-test entry point**
+
+```bash
+ls precious-integration/tests/
+```
+
+Choose: extend an existing file if one already drives end-to-end precious invocations, otherwise
+create `non_utf8_paths.rs`.
+
+- [ ] **Step 2: Write the failing test for a non-UTF-8 filename on disk**
+
+```rust
+#[cfg(unix)]
+#[test]
+fn non_utf8_filename_fails_with_clear_error() -> anyhow::Result<()> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::process::Command;
+
+    let helper = precious_testhelper::TestHelper::new()?.with_git_repo()?;
+    let bad = OsStr::from_bytes(b"data\xff.bin");
+    let mut path = helper.precious_root();
+    path.push(bad);
+    std::fs::write(&path, b"contents")?;
+
+    // Write a minimal precious config that defines no commands so the run
+    // exercises path discovery and nothing else.
+    let cfg = helper.precious_root().join("precious.toml");
+    std::fs::write(&cfg, "[commands]\n")?;
+
+    let out = Command::new(env!("CARGO_BIN_EXE_precious"))
+        .current_dir(helper.precious_root())
+        .args(["--config", "precious.toml", "lint", "--all"])
+        .output()?;
+
+    assert_ne!(out.status.code(), Some(0), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("non-UTF-8 path from filesystem walk"),
+        "expected fail-fast diagnostic, got stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(r"data\xff.bin"),
+        "expected raw-byte escape in stderr, got:\n{stderr}",
+    );
+    Ok(())
+}
+```
+
+Run: `cargo test -p precious-integration non_utf8_filename_fails_with_clear_error` Expected: PASS
+(the migration in Tasks 1–7 should already make this work). If the assertion fails because of a
+different exit path (e.g. the empty config errors before discovery), adjust the config to declare a
+no-op lint command that operates on `**/*` so discovery actually runs.
+
+- [ ] **Step 3: Write the `café.txt` regression test**
+
+```rust
+#[test]
+fn cafe_txt_handled_through_git() -> anyhow::Result<()> {
+    use std::process::Command;
+
+    let helper = precious_testhelper::TestHelper::new()?.with_git_repo()?;
+    let name = "café.txt";
+    std::fs::write(helper.precious_root().join(name), "hello")?;
+
+    Command::new("git")
+        .current_dir(helper.precious_root())
+        .args(["add", name])
+        .status()?;
+
+    let cfg = helper.precious_root().join("precious.toml");
+    std::fs::write(
+        &cfg,
+        // A no-op lint that just echoes filenames so the run succeeds.
+        r#"[commands.echo]
+type = "lint"
+include = "**/*"
+cmd = ["true"]
+ok-exit-codes = [0]
+"#,
+    )?;
+
+    let out = Command::new(env!("CARGO_BIN_EXE_precious"))
+        .current_dir(helper.precious_root())
+        .args(["--config", "precious.toml", "lint", "--staged"])
+        .output()?;
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Ok(())
+}
+```
+
+(The exact config keys must match the project's current TOML schema — read an existing example from
+`precious-core/src/config.rs` tests or `Changes.md` to confirm.)
+
+Run: `cargo test -p precious-integration cafe_txt_handled_through_git` Expected: PASS. The `-z`
+change to `git ls-files` is what makes this case work — without it, git C-quotes `caf\303\251.txt`
+and the path no longer resolves to disk.
+
+- [ ] **Step 4: Run the full test suite once more**
+
+Run: `cargo test --workspace` Expected: PASS.
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings` Expected: clean.
+
+- [ ] **Step 5: Tidy and commit**
+
+```bash
+mise exec precious -- precious tidy precious-integration
+git add precious-integration
+git commit -m "Add integration tests for non-UTF-8 path fail-fast and café.txt regression"
+```
+
+---
+
+## Task 9: Documentation and changelog
+
+**Files:**
+
+- Modify: `Changes.md`.
+
+- [ ] **Step 1: Add a `Changes.md` entry**
+
+Following the format of the most-recent entries (read the top of `Changes.md` first), add a new
+entry under the unreleased section:
+
+```
+* Precious now fails fast with a clear error when it encounters a file path
+  that is not valid UTF-8, instead of silently lossy-converting. Previously
+  non-UTF-8 paths were corrupted at the `git ls-files` decode step and at
+  subprocess-argument construction. The error message includes both a
+  human-readable lossy approximation and the exact raw bytes of the path.
+  Internally, `precious-core` now uses `camino::Utf8PathBuf` throughout so
+  the UTF-8 invariant is enforced by the type system.
+```
+
+- [ ] **Step 2: Tidy and commit**
+
+```bash
+mise exec precious -- precious tidy Changes.md
+git add Changes.md
+git commit -m "Document UTF-8 fail-fast behavior in Changes.md"
+```
+
+---
+
+## Post-flight
+
+- [ ] Run `git log --oneline origin/master..` to confirm the commit list reads cleanly (spec, exec
+      raw-bytes, big migration, integration tests, changelog).
+- [ ] Remove the loose-end directory mentioned in the handoff if it still exists:
+
+```bash
+rmdir /home/autarch/projects/precious/.claude/worktrees 2>/dev/null || true
+```
+
+- [ ] Delete the handoff document — its content is now superseded by the merged work:
+
+```bash
+git rm docs/superpowers/specs/2026-05-30-utf8-path-handling-HANDOFF.md
+git commit -m "Remove session handoff doc"
+```
+
+(Only run that final `git rm` if the user confirms; it's tracked here as a checkbox so it doesn't
+get forgotten.)
+
+- [ ] Hand off to user for review / merge using the `superpowers:finishing-a-development-branch`
+      skill.

--- a/docs/superpowers/specs/2026-05-30-utf8-path-handling-design.md
+++ b/docs/superpowers/specs/2026-05-30-utf8-path-handling-design.md
@@ -1,0 +1,156 @@
+# UTF-8 Path Handling Design
+
+Date: 2026-05-30
+
+## Problem
+
+Precious does not handle file paths that are not valid UTF-8 in a coherent way. Today it preserves
+such paths in some places and silently corrupts them in others:
+
+- Filesystem discovery via the `ignore` crate preserves the raw bytes as `PathBuf` (lossless).
+- `git ls-files` output is decoded with `String::from_utf8_lossy`, so non-UTF-8 bytes become the
+  U+FFFD replacement character before the path ever becomes a `PathBuf`. The resulting path no
+  longer matches the real file on disk.
+- Subprocess invocation converts paths to arguments with `to_string_lossy`, again corrupting any
+  non-UTF-8 bytes before passing them to the linter or formatter.
+- Error and log output uses `to_string_lossy` everywhere, so the user sees garbled paths with no
+  indication that anything was lost.
+
+The net effect is that precious cannot reliably operate on files whose names are not valid UTF-8,
+and it gives no clear diagnostic explaining why.
+
+## Goal
+
+Any encounter with a non-UTF-8 path produces a clear, immediate error for the user. Precious must
+never silently lossy-convert a path. The UTF-8 invariant should be enforced by the type system so
+the bug cannot be reintroduced.
+
+## Decisions
+
+- **Severity: fail fast.** On encountering a non-UTF-8 path, abort the entire run with a clear error
+  and a non-zero exit code. No command runs against a corrupted name.
+- **Detection sites:** all places a non-UTF-8 path can enter the system — CLI arguments, filesystem
+  walk results, `git ls-files` output, and the git root path. Config-file path lists are already
+  guaranteed UTF-8 (they come from TOML strings) and require no runtime check, only a type change.
+- **Error grouping: report the first bad path, then abort.** A single clear error; the user fixes
+  one at a time.
+- **Display format: lossy + escaped bytes.** The message shows both the human-friendly lossy
+  approximation and the exact raw bytes, e.g.
+  `non-UTF-8 path from git ls-files: "data�.bin" (raw bytes: "data\xff.bin")`.
+
+## Architecture
+
+Replace `PathBuf` / `Path` with `camino::Utf8PathBuf` / `Utf8Path` throughout `precious-core`. The
+UTF-8 invariant is then enforced by the type system: the only `Path → Utf8Path` conversions happen
+at the entry points, every such conversion is fallible and produces a clear error, and downstream
+code cannot perform a lossy conversion because there is no `PathBuf` left to convert.
+
+Add `camino` to the workspace with the `serde` feature so `Utf8PathBuf` fields in the config
+deserialize directly from TOML.
+
+A new module `precious-core/src/paths/utf8.rs` defines the error type:
+
+```rust
+pub enum NonUtf8Source {
+    FilesystemWalk,
+    GitLsFiles,
+    GitRoot,
+    DerivedPath, // result of canonicalize / pathdiff that failed UTF-8 conversion
+}
+
+pub struct NonUtf8PathError {
+    pub raw: PathBuf,          // original bytes, for the error message
+    pub source: NonUtf8Source,
+}
+```
+
+`Display for NonUtf8PathError` renders the lossy + escaped-bytes form described above. The error
+converts into `anyhow::Error` and flows into the existing top-level handler in
+`precious-core/src/precious.rs`, which already exits with status 1 and prints the message to stderr.
+No new plumbing is required past the entry points.
+
+### CLI arguments need no custom code
+
+Declaring the clap path field as `Vec<Utf8PathBuf>` makes clap reject a non-UTF-8 argument with its
+own "invalid UTF-8" usage error (exit code 2) before precious sees it. Therefore `NonUtf8Source` has
+no `CliArg` variant. The slightly different exit code (clap's 2 vs. precious's 1) is acceptable;
+both are clear, immediate errors.
+
+## Components & Data Flow
+
+End to end: **discovery validates → everything downstream is statically UTF-8 → subprocess
+invocation and output are byte-faithful.**
+
+### `paths/finder.rs` — discovery boundaries
+
+- **Filesystem walk:** each `ent.path()` from the `ignore` walker goes through
+  `Utf8Path::from_path(p).ok_or_else(|| NonUtf8PathError { source: FilesystemWalk, .. })?`. The
+  first failure aborts the walk and propagates.
+- **git ls-files:** switch the invocation to `-z` (NUL-separated output, which also disables git's
+  default C-quoting of non-ASCII bytes). Read stdout as raw `Vec<u8>`, split on `0x00`, and validate
+  each entry with `str::from_utf8` → `Utf8PathBuf` or `NonUtf8PathError { source: GitLsFiles, .. }`.
+  This replaces the current `from_utf8_lossy` decode on this call path.
+- **git root:** validate the trimmed stdout as UTF-8 → `Utf8PathBuf` or
+  `NonUtf8PathError { source: GitRoot, .. }`.
+- `Finder::files` signature becomes
+  `fn files(&mut self, cli_paths: Vec<Utf8PathBuf>) -> Result<Option<Vec1<Utf8PathBuf>>>`.
+
+### `command.rs` — consumes only `Utf8Path`
+
+- Subprocess args: pass `Utf8Path` directly to `Command::arg` (it is `AsRef<OsStr>`) or use
+  `.as_str()` / `.to_string()`. No lossy conversion.
+- `fs::*` calls bridge to std via `Utf8Path::as_std_path()` (or camino's `read_dir_utf8`).
+- `pathdiff` / `canonicalize` return std `PathBuf`; wrap their results with
+  `Utf8PathBuf::try_from(...)`, mapping failure to `NonUtf8PathError { source: DerivedPath, .. }`.
+  These derive from already-validated inputs, but the OS-provided absolute-path prefix is the one
+  component not yet validated, so the conversion remains fallible for correctness rather than
+  panicking.
+- The `to_string_lossy()` sites in log and error messages become `.as_str()` or direct `Display`.
+
+### `config.rs`, `config_init.rs`, `matcher.rs`
+
+- `WorkingDir::ChdirTo` and any other path fields become `Utf8PathBuf`, deserialized directly from
+  TOML (already UTF-8).
+- `config_init.rs` and `matcher.rs` follow mechanically from the type change.
+
+## Error Handling
+
+- All discovery boundaries and the derived-path conversion produce `NonUtf8PathError`, converted to
+  `anyhow::Error` and surfaced by the existing top-level handler → exit 1, message on stderr. The
+  first bad path aborts.
+- CLI arguments are rejected by clap directly → exit 2. Noted as an intentional difference rather
+  than worked around.
+- No code path panics on a non-UTF-8 path; every conversion is fallible and yields the clear error.
+
+## Testing
+
+### Unit tests (run on all platforms, no disk writes, no gating)
+
+- `paths/utf8.rs`: `Display` formatting for `NonUtf8PathError`, including the lossy + escaped-bytes
+  rendering, driven by an in-memory byte sequence containing an invalid byte (e.g. `0xFF`).
+  Constructed in memory via `OsStr`/`Vec<u8>`; nothing is written to disk, so these run on every
+  platform without gating.
+
+### Integration tests (`precious-integration`)
+
+- A real run against a checkout containing a file whose name is not valid UTF-8 exits non-zero with
+  the expected stderr. This guards the end-to-end behavior, including the `-z` git change, covering
+  both the filesystem-walk and git-ls-files discovery paths.
+- A regression test confirms that a _valid_ non-ASCII UTF-8 name (`café.txt`) is handled correctly
+  through git — the `-z` change fixes the previously-broken C-quoting case — proving the change
+  rejects only genuinely invalid UTF-8, not all non-ASCII names.
+
+### Cross-platform gating
+
+Only tests that actually write a non-UTF-8 filename to disk require gating, because such names
+cannot be created on Windows. These tests are conditionally compiled / skipped on Windows (e.g.
+`#[cfg_attr(windows, ignore)]` or a `#[cfg(unix)]` guard with a comment explaining the platform
+limitation) and use `std::os::unix::ffi::OsStrExt::from_bytes` to construct the illegal name on
+unix. Unit tests do not write to disk and are therefore not gated.
+
+## Out of Scope
+
+- Windows ill-formed UTF-16 path names. The unix byte-construction approach does not apply on
+  Windows, and camino enforces the UTF-8 invariant on all platforms regardless. Behavior there is
+  left unverified by tests but is still correct by construction.
+- Any configurable "skip and continue" behavior. The chosen behavior is unconditional fail-fast.

--- a/precious-core/Cargo.toml
+++ b/precious-core/Cargo.toml
@@ -10,8 +10,8 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+camino.workspace = true
 clap.workspace = true
-clean-path.workspace = true
 comfy-table.workspace = true
 fern.workspace = true
 ignore.workspace = true

--- a/precious-core/src/command.rs
+++ b/precious-core/src/command.rs
@@ -1,5 +1,9 @@
-use crate::paths::matcher::{Matcher, MatcherBuilder};
+use crate::paths::{
+    matcher::{Matcher, MatcherBuilder},
+    utf8::{NonUtf8PathError, NonUtf8Source},
+};
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 use log::{debug, info};
 use mitsein::prelude::*;
@@ -11,7 +15,6 @@ use std::{
     fmt, fs,
     io::ErrorKind,
     num::NonZeroUsize,
-    path::{Path, PathBuf},
     time::SystemTime,
 };
 use thiserror::Error;
@@ -109,7 +112,7 @@ impl ActualInvoke {
 pub enum WorkingDir {
     Root,
     Dir,
-    ChdirTo(PathBuf),
+    ChdirTo(Utf8PathBuf),
 }
 
 impl TryFrom<&str> for WorkingDir {
@@ -131,7 +134,7 @@ impl fmt::Display for WorkingDir {
             WorkingDir::Dir => f.write_str(r#""dir""#),
             WorkingDir::ChdirTo(cd) => {
                 f.write_str(r#"chdir-to = ""#)?;
-                f.write_str(&format!("{}", cd.display()))?;
+                f.write_str(cd.as_str())?;
                 f.write_str(r#"""#)
             }
         }
@@ -191,7 +194,7 @@ enum CommandError {
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct Command {
-    project_root: PathBuf,
+    project_root: Utf8PathBuf,
     pub name: String,
     typ: CommandType,
     filter: Filter,
@@ -227,7 +230,7 @@ struct Execution {
 
 #[derive(Debug)]
 pub struct CommandParams {
-    pub project_root: PathBuf,
+    pub project_root: Utf8PathBuf,
     pub name: String,
     pub typ: CommandType,
     pub include: Vec<String>,
@@ -262,8 +265,8 @@ pub struct LintOutcome {
 
 #[derive(Clone, Debug)]
 struct PathMetadata {
-    dir: Option<PathBuf>,
-    path_map: HashMap<PathBuf, PathInfo>,
+    dir: Option<Utf8PathBuf>,
+    path_map: HashMap<Utf8PathBuf, PathInfo>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -390,8 +393,8 @@ impl Command {
     // determined based on the command's `path-args` field.
     pub fn files_to_args_sets<'a>(
         &self,
-        files: &'a Slice1<PathBuf>,
-    ) -> Result<(Vec<Vec1<&'a Path>>, ActualInvoke)> {
+        files: &'a Slice1<Utf8PathBuf>,
+    ) -> Result<(Vec<Vec1<&'a Utf8Path>>, ActualInvoke)> {
         let files = self.filter_and_sort_files(files);
         if files.is_empty() {
             return Ok((vec![], self.invocation.invoke.into()));
@@ -408,16 +411,16 @@ impl Command {
         }
     }
 
-    fn filter_and_sort_files<'a>(&self, files: &'a Slice1<PathBuf>) -> Vec<&'a Path> {
+    fn filter_and_sort_files<'a>(&self, files: &'a Slice1<Utf8PathBuf>) -> Vec<&'a Utf8Path> {
         files
             .into_iter()
             .filter(|f| self.file_matches_rules(f))
             .sorted()
-            .map(PathBuf::as_path)
+            .map(Utf8PathBuf::as_path)
             .collect::<Vec<_>>()
     }
 
-    fn handle_per_file(files: Vec1<&Path>) -> (Vec<Vec1<&Path>>, ActualInvoke) {
+    fn handle_per_file(files: Vec1<&Utf8Path>) -> (Vec<Vec1<&Utf8Path>>, ActualInvoke) {
         // Every file becomes its own one-element `Vec1`.
         (
             files.into_iter().map(|f| vec1![f]).collect(),
@@ -427,9 +430,9 @@ impl Command {
 
     fn handle_per_file_or_dir<'a>(
         &self,
-        files: Vec1<&'a Path>,
+        files: Vec1<&'a Utf8Path>,
         n: usize,
-    ) -> Result<(Vec<Vec1<&'a Path>>, ActualInvoke)> {
+    ) -> Result<(Vec<Vec1<&'a Utf8Path>>, ActualInvoke)> {
         let count = files.len();
         let threshold = NonZeroUsize::new(n).expect("this cannot be 0");
 
@@ -453,9 +456,9 @@ impl Command {
 
     fn handle_per_file_or_once<'a>(
         &self,
-        files: Vec1<&'a Path>,
+        files: Vec1<&'a Utf8Path>,
         n: usize,
-    ) -> (Vec<Vec1<&'a Path>>, ActualInvoke) {
+    ) -> (Vec<Vec1<&'a Utf8Path>>, ActualInvoke) {
         let count = files.len();
         let threshold = NonZeroUsize::new(n).expect("this cannot be 0");
 
@@ -480,16 +483,18 @@ impl Command {
         }
     }
 
-    fn handle_per_dir<'a>(files: &Slice1<&'a Path>) -> Result<(Vec<Vec1<&'a Path>>, ActualInvoke)> {
+    fn handle_per_dir<'a>(
+        files: &Slice1<&'a Utf8Path>,
+    ) -> Result<(Vec<Vec1<&'a Utf8Path>>, ActualInvoke)> {
         // Every directory becomes a Vec of its files.
         Ok((Self::files_by_dir(files)?, ActualInvoke::PerDir))
     }
 
     fn handle_per_dir_or_once<'a>(
         &self,
-        files: Vec1<&'a Path>,
+        files: Vec1<&'a Utf8Path>,
         n: usize,
-    ) -> Result<(Vec<Vec1<&'a Path>>, ActualInvoke)> {
+    ) -> Result<(Vec<Vec1<&'a Utf8Path>>, ActualInvoke)> {
         let files_by_dir = Self::files_by_dir(&files)?;
         let count = files_by_dir.len();
         if count < n {
@@ -507,7 +512,7 @@ impl Command {
         }
     }
 
-    fn handle_once(files: Vec1<&Path>) -> (Vec<Vec1<&Path>>, ActualInvoke) {
+    fn handle_once(files: Vec1<&Utf8Path>) -> (Vec<Vec1<&Utf8Path>>, ActualInvoke) {
         // All files in one Vec.
         (
             vec![Vec1::try_from(files).expect("we already know this is a non-zero vec")],
@@ -517,7 +522,7 @@ impl Command {
 
     // This returns a `Vec` of `Vec`s, where the inner `Vec` contains all the files in a given
     // directory, and the outer `Vec` contains one element per directory.
-    fn files_by_dir<'a>(files: &Slice1<&'a Path>) -> Result<Vec<Vec1<&'a Path>>> {
+    fn files_by_dir<'a>(files: &Slice1<&'a Utf8Path>) -> Result<Vec<Vec1<&'a Utf8Path>>> {
         let by_dir = Self::files_by_dir_hashmap(files)?;
         Ok(by_dir
             .into_iter()
@@ -527,12 +532,12 @@ impl Command {
     }
 
     fn files_by_dir_hashmap<'a>(
-        files: &Slice1<&'a Path>,
-    ) -> Result<HashMap<&'a Path, Vec1<&'a Path>>> {
-        let mut by_dir: HashMap<&Path, Vec1<&Path>> = HashMap::new();
+        files: &Slice1<&'a Utf8Path>,
+    ) -> Result<HashMap<&'a Utf8Path, Vec1<&'a Utf8Path>>> {
+        let mut by_dir: HashMap<&Utf8Path, Vec1<&Utf8Path>> = HashMap::new();
         for f in files {
             let d = f.parent().ok_or_else(|| CommandError::PathHasNoParent {
-                path: f.to_string_lossy().to_string(),
+                path: f.as_str().to_string(),
             })?;
             if let Some(v) = by_dir.get_mut(d) {
                 v.push(*f);
@@ -546,7 +551,7 @@ impl Command {
     pub fn tidy(
         &self,
         actual_invoke: ActualInvoke,
-        files: &Slice1<&Path>,
+        files: &Slice1<&Utf8Path>,
     ) -> Result<Option<TidyOutcome>> {
         self.require_is_not_command_type("tidy", CommandType::Lint)?;
 
@@ -592,7 +597,7 @@ impl Command {
             "Tidying [{}] with {} in [{}] using command [{}]",
             file_summary_for_log(files),
             self.name,
-            in_dir.display(),
+            in_dir,
             exec.loggable_command,
         );
         exec.run()
@@ -615,7 +620,7 @@ impl Command {
     pub fn lint(
         &self,
         actual_invoke: ActualInvoke,
-        files: &Slice1<&Path>,
+        files: &Slice1<&Utf8Path>,
     ) -> Result<Option<LintOutcome>> {
         self.require_is_not_command_type("lint", CommandType::Tidy)?;
 
@@ -653,7 +658,7 @@ impl Command {
             "Linting [{}] with {} in [{}] using command [{}]",
             file_summary_for_log(files),
             self.name,
-            in_dir.display(),
+            in_dir,
             exec.loggable_command,
         );
 
@@ -690,7 +695,7 @@ impl Command {
     fn should_act_on_files(
         &self,
         actual_invoke: ActualInvoke,
-        files: &Slice1<&Path>,
+        files: &Slice1<&Utf8Path>,
     ) -> Result<bool> {
         match actual_invoke {
             ActualInvoke::PerFile => {
@@ -698,19 +703,11 @@ impl Command {
                 // This check isn't strictly necessary since we default to not
                 // matching, but the debug output is helpful.
                 if self.filter.excluder.path_matches(f, false) {
-                    debug!(
-                        "File {} is excluded for the {} command",
-                        f.display(),
-                        self.name,
-                    );
+                    debug!("File {} is excluded for the {} command", f, self.name);
                     return Ok(false);
                 }
                 if self.filter.includer.path_matches(f, false) {
-                    debug!(
-                        "File {} is included for the {} command",
-                        f.display(),
-                        self.name,
-                    );
+                    debug!("File {} is included for the {} command", f, self.name);
                     return Ok(true);
                 }
             }
@@ -718,49 +715,37 @@ impl Command {
                 let dir = files[0]
                     .parent()
                     .ok_or_else(|| CommandError::PathHasNoParent {
-                        path: files[0].to_string_lossy().to_string(),
+                        path: files[0].as_str().to_string(),
                     })?;
                 for f in files {
                     if self.filter.excluder.path_matches(f, false) {
-                        debug!(
-                            "File {} is excluded for the {} command",
-                            f.display(),
-                            self.name,
-                        );
+                        debug!("File {} is excluded for the {} command", f, self.name);
                         continue;
                     }
                     if self.filter.includer.path_matches(f, false) {
                         debug!(
                             "Directory {} is included for the {} command because it contains {} which is included",
-                            dir.display(),
+                            dir,
                             self.name,
-                            f.display(),
+                            f,
                         );
                         return Ok(true);
                     }
                 }
                 debug!(
                     "Directory {} is not included in the {} command because none of its files are included",
-                    dir.display(),
+                    dir,
                     self.name
                 );
             }
             ActualInvoke::Once => {
                 for f in files {
                     if self.filter.excluder.path_matches(f, false) {
-                        debug!(
-                            "File {} is excluded for the {} command",
-                            f.display(),
-                            self.name,
-                        );
+                        debug!("File {} is excluded for the {} command", f, self.name);
                         continue;
                     }
                     if self.filter.includer.path_matches(f, false) {
-                        debug!(
-                            "File {} is included for the {} command",
-                            f.display(),
-                            self.name,
-                        );
+                        debug!("File {} is included for the {} command", f, self.name);
                         return Ok(true);
                     }
                 }
@@ -783,23 +768,27 @@ impl Command {
     // them as is (but sorted), or we may turn them paths relative to the
     // given directory. The given directory is the directory in which the
     // command will be run, and may not be the project root.
-    fn operating_on(&self, files: &Slice1<&Path>, in_dir: &Path) -> Result<Vec<PathBuf>> {
+    fn operating_on(
+        &self,
+        files: &Slice1<&Utf8Path>,
+        in_dir: &Utf8Path,
+    ) -> Result<Vec<Utf8PathBuf>> {
         match self.invocation.path_args {
-            PathArgs::File => Ok(files
+            PathArgs::File => files
                 .iter()
                 .sorted()
                 .map(|r| self.path_relative_to(r, in_dir))
-                .collect::<Vec<_>>()),
+                .collect::<Result<Vec<_>>>(),
             PathArgs::Dir => Self::files_by_dir_hashmap(files)
                 .context(r#"Failed to group files by directory for path-args = "dir""#)
-                .map(|fm| {
+                .and_then(|fm| {
                     fm.into_keys()
                         .sorted()
                         .map(|r| self.path_relative_to(r, in_dir))
-                        .collect::<Vec<_>>()
+                        .collect::<Result<Vec<_>>>()
                 }),
             PathArgs::None => Ok(vec![]),
-            PathArgs::Dot => Ok(vec![PathBuf::from(".")]),
+            PathArgs::Dot => Ok(vec![Utf8PathBuf::from(".")]),
             PathArgs::AbsoluteFile => Ok(files
                 .iter()
                 .sorted()
@@ -826,18 +815,28 @@ impl Command {
         }
     }
 
-    fn path_relative_to(&self, path: &Path, in_dir: &Path) -> PathBuf {
+    fn path_relative_to(&self, path: &Utf8Path, in_dir: &Utf8Path) -> Result<Utf8PathBuf> {
         let mut abs = self.project_root.clone();
         abs.push(path);
 
-        if let Some(mut diff) = pathdiff::diff_paths(&abs, in_dir) {
-            if diff == Path::new("") {
-                diff = PathBuf::from(".");
+        if let Some(diff) = pathdiff::diff_paths(&abs, in_dir) {
+            if diff == std::path::Path::new("") {
+                return Ok(Utf8PathBuf::from("."));
             }
-            return diff;
+            // Both inputs are already validated `Utf8Path`, so pathdiff's result is UTF-8 by
+            // construction. The `try_from` is necessary because the OS-provided absolute-path
+            // prefix that `pathdiff` may produce when bridging through `std::path::Path` is the
+            // one component not yet UTF-8-validated.
+            return Utf8PathBuf::try_from(diff).map_err(|e| {
+                NonUtf8PathError {
+                    raw: e.into_path_buf(),
+                    source: NonUtf8Source::DerivedPath,
+                }
+                .into()
+            });
         }
 
-        path.to_path_buf()
+        Ok(path.to_path_buf())
     }
 
     // This takes the list of files relevant to the command. That list comes
@@ -849,7 +848,7 @@ impl Command {
     fn maybe_path_metadata_for(
         &self,
         actual_invoke: ActualInvoke,
-        files: &Slice1<&Path>,
+        files: &Slice1<&Utf8Path>,
     ) -> Result<Option<PathMetadata>> {
         match actual_invoke {
             // If it's invoked per file we know that we only have one file in
@@ -861,7 +860,7 @@ impl Command {
                 let dir = files[0]
                     .parent()
                     .ok_or_else(|| CommandError::PathHasNoParent {
-                        path: files[0].to_string_lossy().to_string(),
+                        path: files[0].as_str().to_string(),
                     })?;
                 Ok(Some(self.path_metadata_for(dir)?))
             }
@@ -874,44 +873,38 @@ impl Command {
 
     // Given a directory, this gets the metadata for all files in the
     // directory that match the command's include/exclude rules.
-    fn path_metadata_for(&self, path: &Path) -> Result<PathMetadata> {
+    fn path_metadata_for(&self, path: &Utf8Path) -> Result<PathMetadata> {
         let mut path_map = HashMap::new();
         let mut dir = None;
         let mut full_path = self.project_root.clone();
         full_path.push(path);
 
         if full_path.is_file() {
-            let meta = Self::metadata_for_file(&full_path).with_context(|| {
-                format!("Failed to get metadata for file {}", full_path.display())
-            })?;
+            let meta = Self::metadata_for_file(&full_path)
+                .with_context(|| format!("Failed to get metadata for file {full_path}"))?;
             path_map.insert(full_path, meta);
         } else if full_path.is_dir() {
             dir = Some(path.to_path_buf());
-            let entries = fs::read_dir(&full_path)
-                .with_context(|| format!("Failed to read directory {}", full_path.display()))?;
+            let entries = full_path
+                .read_dir_utf8()
+                .with_context(|| format!("Failed to read directory {full_path}"))?;
             for entry in entries {
-                let entry = entry.with_context(|| {
-                    format!(
-                        "Failed to read directory entry from {}",
-                        full_path.display()
-                    )
-                })?;
+                let entry = entry
+                    .with_context(|| format!("Failed to read directory entry from {full_path}"))?;
                 let path = entry.path();
-                if path.is_file() && self.file_matches_rules(&path) {
-                    let meta = entry.metadata().with_context(|| {
-                        format!("Failed to get metadata for file {}", path.display())
-                    })?;
-                    let hash = md5::compute(fs::read(&path).with_context(|| {
-                        format!("Failed to read file {} for MD5 hashing", path.display())
-                    })?);
+                if path.is_file() && self.file_matches_rules(path) {
+                    let meta = entry
+                        .metadata()
+                        .with_context(|| format!("Failed to get metadata for file {path}"))?;
+                    let hash =
+                        md5::compute(fs::read(path).with_context(|| {
+                            format!("Failed to read file {path} for MD5 hashing")
+                        })?);
                     let mtime = meta.modified().with_context(|| {
-                        format!(
-                            "Failed to get modification time for file {}",
-                            path.display()
-                        )
+                        format!("Failed to get modification time for file {path}")
                     })?;
                     path_map.insert(
-                        path,
+                        path.to_path_buf(),
                         PathInfo {
                             mtime,
                             size: meta.len(),
@@ -922,7 +915,7 @@ impl Command {
             }
         } else if !path.exists() {
             return Err(CommandError::PathDoesNotExist {
-                path: path.to_string_lossy().to_string(),
+                path: path.as_str().to_string(),
             }
             .into());
         } else {
@@ -934,7 +927,7 @@ impl Command {
         Ok(PathMetadata { dir, path_map })
     }
 
-    fn file_matches_rules(&self, file: &Path) -> bool {
+    fn file_matches_rules(&self, file: &Utf8Path) -> bool {
         if self.filter.excluder.path_matches(file, false) {
             return false;
         }
@@ -944,19 +937,17 @@ impl Command {
         false
     }
 
-    fn metadata_for_file(file: &Path) -> Result<PathInfo> {
-        let meta = fs::metadata(file)
-            .with_context(|| format!("Failed to get metadata for file {}", file.display()))?;
-        let mtime = meta.modified().with_context(|| {
-            format!(
-                "Failed to get modification time for file {}",
-                file.display()
-            )
-        })?;
-        let hash =
-            md5::compute(fs::read(file).with_context(|| {
-                format!("Failed to read file {} for MD5 hashing", file.display())
-            })?);
+    fn metadata_for_file(file: &Utf8Path) -> Result<PathInfo> {
+        let meta = file
+            .metadata()
+            .with_context(|| format!("Failed to get metadata for file {file}"))?;
+        let mtime = meta
+            .modified()
+            .with_context(|| format!("Failed to get modification time for file {file}"))?;
+        let hash = md5::compute(
+            fs::read(file)
+                .with_context(|| format!("Failed to read file {file} for MD5 hashing"))?,
+        );
         Ok(PathInfo {
             mtime,
             size: meta.len(),
@@ -967,7 +958,7 @@ impl Command {
     fn cmd_and_args_for_exec(
         &self,
         flags: Option<&[String]>,
-        paths: &[PathBuf],
+        paths: &[Utf8PathBuf],
     ) -> (String, Vec<String>) {
         let mut args = self.execution.cmd.clone();
         let cmd = args.remove(0);
@@ -982,7 +973,7 @@ impl Command {
             if let Some(pf) = &self.execution.path_flag {
                 args.push(pf.clone());
             }
-            args.push(p.to_string_lossy().to_string());
+            args.push(p.as_str().to_string());
         }
 
         (cmd, args)
@@ -991,12 +982,12 @@ impl Command {
     pub(crate) fn paths_summary(
         &self,
         actual_invoke: ActualInvoke,
-        paths: &Slice1<&Path>,
+        paths: &Slice1<&Utf8Path>,
     ) -> String {
         let all = paths
             .iter1()
             .sorted()
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| p.as_str().to_string())
             .into_iter()
             .join(" ");
         if paths.len() <= NonZeroUsize::new(3).unwrap() {
@@ -1005,12 +996,7 @@ impl Command {
 
         match actual_invoke {
             ActualInvoke::Once | ActualInvoke::PerDir => {
-                let initial = paths
-                    .iter()
-                    .sorted()
-                    .take(2)
-                    .map(|p| p.to_string_lossy())
-                    .join(" ");
+                let initial = paths.iter().sorted().take(2).map(|p| p.as_str()).join(" ");
                 format!(
                     "{} files matching {}, starting with {}",
                     paths.len(),
@@ -1024,16 +1010,15 @@ impl Command {
 
     fn paths_were_changed(&self, prev: PathMetadata) -> Result<bool> {
         for (prev_file, prev_meta) in &prev.path_map {
-            debug!("Checking {} for changes", prev_file.display());
-            let current_meta = match fs::metadata(prev_file) {
+            debug!("Checking {prev_file} for changes");
+            let current_meta = match prev_file.metadata() {
                 Ok(m) => m,
                 // If the file no longer exists the command must've deleted
                 // it.
                 Err(e) if e.kind() == ErrorKind::NotFound => return Ok(true),
                 Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!("Failed to get metadata for file {}", prev_file.display())
-                    })
+                    return Err(e)
+                        .with_context(|| format!("Failed to get metadata for file {prev_file}"))
                 }
             };
             // If the mtime is unchanged we don't need to compare anything
@@ -1041,12 +1026,9 @@ impl Command {
             // the mtime even if it doesn't change the file's contents, so we
             // cannot assume anything was changed just because the mtime
             // changed. For example, Perl::Tidy does this :(
-            let current_mtime = current_meta.modified().with_context(|| {
-                format!(
-                    "Failed to get modification time for file {}",
-                    prev_file.display()
-                )
-            })?;
+            let current_mtime = current_meta
+                .modified()
+                .with_context(|| format!("Failed to get modification time for file {prev_file}"))?;
             if prev_meta.mtime == current_mtime {
                 continue;
             }
@@ -1057,34 +1039,28 @@ impl Command {
             }
 
             // Otherwise we need to compare the content hash.
-            let current_hash = md5::compute(fs::read(prev_file).with_context(|| {
-                format!(
-                    "Failed to read file {} for MD5 hashing",
-                    prev_file.display()
-                )
-            })?);
+            let current_hash = md5::compute(
+                fs::read(prev_file)
+                    .with_context(|| format!("Failed to read file {prev_file} for MD5 hashing"))?,
+            );
             if prev_meta.hash != current_hash {
                 return Ok(true);
             }
         }
 
         if let Some(dir) = prev.dir {
-            let entries = match fs::read_dir(&dir) {
+            let entries = match dir.read_dir_utf8() {
                 Ok(rd) => rd,
                 Err(e) if e.kind() == ErrorKind::NotFound => return Ok(true),
-                Err(e) => {
-                    return Err(e)
-                        .with_context(|| format!("Failed to read directory {}", dir.display()))
-                }
+                Err(e) => return Err(e).with_context(|| format!("Failed to read directory {dir}")),
             };
             for entry in entries {
-                let entry = entry.with_context(|| {
-                    format!("Failed to read directory entry from {}", dir.display())
-                })?;
+                let entry =
+                    entry.with_context(|| format!("Failed to read directory entry from {dir}"))?;
                 let path = entry.path();
                 if path.is_file()
-                    && self.file_matches_rules(&path)
-                    && !prev.path_map.contains_key(&path)
+                    && self.file_matches_rules(path)
+                    && !prev.path_map.contains_key(path)
                 {
                     return Ok(true);
                 }
@@ -1105,14 +1081,14 @@ impl Command {
         name.to_string()
     }
 
-    fn in_dir(&self, file: &Path) -> Result<PathBuf> {
+    fn in_dir(&self, file: &Utf8Path) -> Result<Utf8PathBuf> {
         match &self.invocation.working_dir {
             WorkingDir::Root => Ok(self.project_root.clone()),
             WorkingDir::Dir => {
                 let mut abs = self.project_root.clone();
                 abs.push(file);
                 let parent = abs.parent().ok_or_else(|| CommandError::PathHasNoParent {
-                    path: file.to_string_lossy().to_string(),
+                    path: file.as_str().to_string(),
                 })?;
                 Ok(parent.to_path_buf())
             }
@@ -1132,22 +1108,17 @@ impl Command {
     }
 }
 
-fn file_summary_for_log(files: &Slice1<&Path>) -> String {
+fn file_summary_for_log(files: &Slice1<&Utf8Path>) -> String {
     if files.len() <= NonZeroUsize::new(3).unwrap() {
-        return files.iter().map(|p| p.to_string_lossy()).join(" ");
+        return files.iter().map(|p| p.as_str()).join(" ");
     }
-    let first3 = files.iter().take(3).map(|p| p.to_string_lossy()).join(" ");
+    let first3 = files.iter().take(3).map(|p| p.as_str()).join(" ");
     format!("{} ... and {} more", first3, files.len().get() - 3)
 }
 
-fn replace_root(cmd: &[String], root: &Path) -> Vec<String> {
+fn replace_root(cmd: &[String], root: &Utf8Path) -> Vec<String> {
     cmd.iter()
-        .map(|c| {
-            c.replace(
-                "$PRECIOUS_ROOT",
-                root.to_string_lossy().into_owned().as_str(),
-            )
-        })
+        .map(|c| c.replace("$PRECIOUS_ROOT", root.as_str()))
         .collect()
 }
 
@@ -1155,6 +1126,7 @@ fn replace_root(cmd: &[String], root: &Path) -> Vec<String> {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use camino::{Utf8Path, Utf8PathBuf};
     use precious_testhelper as testhelper;
     use pretty_assertions::assert_eq;
     use serial_test::parallel;
@@ -1169,7 +1141,7 @@ mod tests {
     fn default_command() -> Command {
         Command {
             // These params will be ignored
-            project_root: PathBuf::new(),
+            project_root: Utf8PathBuf::new(),
             name: String::new(),
             typ: CommandType::Lint,
             filter: Filter {
@@ -1195,6 +1167,10 @@ mod tests {
         }
     }
 
+    fn cwd_utf8() -> Utf8PathBuf {
+        Utf8PathBuf::try_from(env::current_dir().unwrap()).expect("cwd is valid UTF-8")
+    }
+
     #[test]
     #[parallel]
     fn files_to_args_sets_per_file() -> Result<()> {
@@ -1202,14 +1178,14 @@ mod tests {
         command.invocation.invoke = Invoke::PerFile;
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
         assert_eq!(
             command.files_to_args_sets(&files)?,
             (
@@ -1233,14 +1209,14 @@ mod tests {
         command.invocation.invoke = Invoke::PerFileOrDir(3);
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
         let two_files = Slice1::try_from_slice(&(*files)[0..2]).unwrap();
         assert_eq!(
             command.files_to_args_sets(two_files)?,
@@ -1273,15 +1249,16 @@ mod tests {
         command.invocation.invoke = Invoke::PerFileOrOnce(3);
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
-        let two_files: &Slice1<PathBuf> = unsafe { Slice1::from_slice_unchecked(&(*files)[0..2]) };
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
+        let two_files: &Slice1<Utf8PathBuf> =
+            unsafe { Slice1::from_slice_unchecked(&(*files)[0..2]) };
         assert_eq!(
             command.files_to_args_sets(two_files)?,
             (
@@ -1314,14 +1291,14 @@ mod tests {
         command.invocation.invoke = Invoke::PerDir;
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
         assert_eq!(
             command.files_to_args_sets(&files)?,
             (
@@ -1344,15 +1321,16 @@ mod tests {
         command.invocation.invoke = Invoke::PerDirOrOnce(3);
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
-        let two_files: &Slice1<PathBuf> = unsafe { Slice1::from_slice_unchecked(&(*files)[0..2]) };
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
+        let two_files: &Slice1<Utf8PathBuf> =
+            unsafe { Slice1::from_slice_unchecked(&(*files)[0..2]) };
         assert_eq!(
             command.files_to_args_sets(two_files)?,
             (
@@ -1385,14 +1363,14 @@ mod tests {
         command.invocation.invoke = Invoke::Once;
         command.filter.includer = matcher(&["**/*.go"])?;
 
-        let files: Vec1<PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
+        let files: Vec1<Utf8PathBuf> = vec1!["foo.go", "test/foo.go", "bar.go", "subdir/baz.go"]
             .into_iter1()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .collect1();
-        let bar = PathBuf::from("bar.go");
-        let foo = PathBuf::from("foo.go");
-        let baz = PathBuf::from("subdir/baz.go");
-        let test_foo = PathBuf::from("test/foo.go");
+        let bar = Utf8PathBuf::from("bar.go");
+        let foo = Utf8PathBuf::from("foo.go");
+        let baz = Utf8PathBuf::from("subdir/baz.go");
+        let test_foo = Utf8PathBuf::from("test/foo.go");
         assert_eq!(
             command.files_to_args_sets(&files)?,
             (
@@ -1479,7 +1457,7 @@ mod tests {
     #[parallel]
     fn should_act_on_files_invoke_per_file() -> Result<()> {
         let mut command = default_command();
-        command.project_root = PathBuf::from("/foo/bar");
+        command.project_root = Utf8PathBuf::from("/foo/bar");
         command.name = String::from("Test");
         command.typ = CommandType::Lint;
         command.filter.includer = matcher(&["**/*.go", "!this/file.go"])?;
@@ -1492,12 +1470,12 @@ mod tests {
             "bar/foo/x.go",
             "foo/some/file.go",
         ];
-        for i in include.iter().map(PathBuf::from) {
+        for i in include.iter().map(Utf8PathBuf::from) {
             let name = i.clone();
             assert!(
-                command.should_act_on_files(ActualInvoke::PerFile, &vec1![i.as_ref()])?,
+                command.should_act_on_files(ActualInvoke::PerFile, &vec1![i.as_path()])?,
                 "{}",
-                name.display(),
+                name,
             );
         }
 
@@ -1508,12 +1486,12 @@ mod tests {
             "foo/bar.go",
             "baz/bar/anything/here/quux/file.go",
         ];
-        for e in exclude.iter().map(PathBuf::from) {
+        for e in exclude.iter().map(Utf8PathBuf::from) {
             let name = e.clone();
             assert!(
-                !command.should_act_on_files(ActualInvoke::PerFile, &vec1![e.as_ref()])?,
+                !command.should_act_on_files(ActualInvoke::PerFile, &vec1![e.as_path()])?,
                 "{}",
-                name.display(),
+                name,
             );
         }
 
@@ -1524,7 +1502,7 @@ mod tests {
     #[parallel]
     fn should_act_on_files_invoke_per_dir() -> Result<()> {
         let mut command = default_command();
-        command.project_root = PathBuf::from("/foo/bar");
+        command.project_root = Utf8PathBuf::from("/foo/bar");
         command.name = String::from("Test");
         command.typ = CommandType::Lint;
         command.filter.includer = matcher(&["**/*.go", "!this/file.go"])?;
@@ -1539,7 +1517,7 @@ mod tests {
             vec1!["foo/some/file.go", "foo/excluded.go"],
         ];
         for i in include.iter() {
-            let files: Vec1<&Path> = i.iter1().map(Path::new).collect1();
+            let files: Vec1<&Utf8Path> = i.iter1().map(Utf8Path::new).collect1();
             assert!(
                 command.should_act_on_files(ActualInvoke::PerDir, &files)?,
                 "{}",
@@ -1554,7 +1532,7 @@ mod tests {
             vec1!["this/file.go", "foo/excluded.go"],
         ];
         for e in exclude.iter() {
-            let files: Vec1<&Path> = e.iter1().map(Path::new).collect1();
+            let files: Vec1<&Utf8Path> = e.iter1().map(Utf8Path::new).collect1();
             assert!(
                 !command.should_act_on_files(ActualInvoke::PerDir, &files)?,
                 "{}",
@@ -1569,7 +1547,7 @@ mod tests {
     #[parallel]
     fn should_act_on_files_invoke_once() -> Result<()> {
         let mut command = default_command();
-        command.project_root = PathBuf::from("/foo/bar");
+        command.project_root = Utf8PathBuf::from("/foo/bar");
         command.name = String::from("Test");
         command.typ = CommandType::Lint;
         command.filter.includer = matcher(&["**/*.go", "!this/file.go"])?;
@@ -1582,13 +1560,13 @@ mod tests {
             [".", "foo/bar.go", "foo/some/file.go"],
         ];
         for i in include.iter() {
-            let dir = PathBuf::from(i[0]);
-            let files: Vec1<&Path> = i[1..].iter().map(Path::new).try_collect1().unwrap();
+            let dir = Utf8PathBuf::from(i[0]);
+            let files: Vec1<&Utf8Path> = i[1..].iter().map(Utf8Path::new).try_collect1().unwrap();
             let name = dir.clone();
             assert!(
                 command.should_act_on_files(ActualInvoke::Once, &files)?,
                 "{}",
-                name.display()
+                name
             );
         }
 
@@ -1603,13 +1581,13 @@ mod tests {
             [".", "this/file.go", "foo/also/excluded.go"],
         ];
         for e in exclude.iter() {
-            let dir = PathBuf::from(e[0]);
-            let files: Vec1<&Path> = e[1..].iter().map(Path::new).try_collect1().unwrap();
+            let dir = Utf8PathBuf::from(e[0]);
+            let files: Vec1<&Utf8Path> = e[1..].iter().map(Utf8Path::new).try_collect1().unwrap();
             let name = dir.clone();
             assert!(
                 !command.should_act_on_files(ActualInvoke::Once, &files)?,
                 "{}",
-                name.display()
+                name
             );
         }
 
@@ -1622,13 +1600,13 @@ mod tests {
         let mut command = default_command();
         command.invocation.path_args = PathArgs::File;
 
-        let file1 = Path::new("file1");
+        let file1 = Utf8Path::new("file1");
         assert_eq!(
             command.operating_on(&vec1![file1], &command.project_root)?,
             vec![file1],
         );
 
-        let file2 = Path::new("subdir/file2");
+        let file2 = Utf8Path::new("subdir/file2");
         assert_eq!(
             command.operating_on(&vec1![file2], &command.project_root)?,
             vec![file2],
@@ -1645,10 +1623,10 @@ mod tests {
 
         let mut in_dir = command.project_root.clone();
         in_dir.push("subdir");
-        let file = Path::new("subdir/file");
+        let file = Utf8Path::new("subdir/file");
         assert_eq!(
             command.operating_on(&vec1![file], &in_dir)?,
-            vec![PathBuf::from("file")],
+            vec![Utf8PathBuf::from("file")],
         );
 
         Ok(())
@@ -1660,10 +1638,10 @@ mod tests {
         let mut command = default_command();
         command.invocation.path_args = PathArgs::Dir;
 
-        let files = vec1![Path::new("file1"), Path::new("subdir/file2")];
+        let files = vec1![Utf8Path::new("file1"), Utf8Path::new("subdir/file2")];
         assert_eq!(
             command.operating_on(&files, &command.project_root)?,
-            vec![PathBuf::from("."), PathBuf::from("subdir")],
+            vec![Utf8PathBuf::from("."), Utf8PathBuf::from("subdir")],
         );
 
         Ok(())
@@ -1675,12 +1653,15 @@ mod tests {
         let mut command = default_command();
         command.invocation.path_args = PathArgs::Dir;
 
-        let files = vec1![Path::new("subdir/file1"), Path::new("subdir/more/file2")];
+        let files = vec1![
+            Utf8Path::new("subdir/file1"),
+            Utf8Path::new("subdir/more/file2")
+        ];
         let mut in_dir = command.project_root.clone();
         in_dir.push("subdir");
         assert_eq!(
             command.operating_on(&files, &in_dir)?,
-            vec![PathBuf::from("."), PathBuf::from("more")],
+            vec![Utf8PathBuf::from("."), Utf8PathBuf::from("more")],
         );
 
         Ok(())
@@ -1689,7 +1670,7 @@ mod tests {
     #[test]
     #[parallel]
     fn operating_on_with_path_args_absolute_file() -> Result<()> {
-        let cwd = env::current_dir()?;
+        let cwd = cwd_utf8();
         let mut command = default_command();
         command.project_root = cwd.clone();
         command.invocation.path_args = PathArgs::AbsoluteFile;
@@ -1697,14 +1678,14 @@ mod tests {
         let mut file1 = cwd.clone();
         file1.push("file1");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("file1")], &command.project_root)?,
+            command.operating_on(&vec1![Utf8Path::new("file1")], &command.project_root)?,
             vec![file1],
         );
 
         let mut file1 = cwd;
         file1.push("subdir/file2");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("subdir/file2")], &command.project_root)?,
+            command.operating_on(&vec1![Utf8Path::new("subdir/file2")], &command.project_root)?,
             vec![file1],
         );
 
@@ -1714,7 +1695,7 @@ mod tests {
     #[test]
     #[parallel]
     fn operating_on_with_path_args_absolute_file_in_dir() -> Result<()> {
-        let cwd = env::current_dir()?;
+        let cwd = cwd_utf8();
         let mut command = default_command();
         command.project_root = cwd.clone();
         command.invocation.path_args = PathArgs::AbsoluteFile;
@@ -1725,14 +1706,14 @@ mod tests {
         let mut file1 = cwd.clone();
         file1.push("file1");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("file1")], &in_dir)?,
+            command.operating_on(&vec1![Utf8Path::new("file1")], &in_dir)?,
             vec![file1],
         );
 
         let mut file1 = cwd;
         file1.push("subdir/file2");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("subdir/file2")], &in_dir)?,
+            command.operating_on(&vec1![Utf8Path::new("subdir/file2")], &in_dir)?,
             vec![file1],
         );
 
@@ -1742,20 +1723,20 @@ mod tests {
     #[test]
     #[parallel]
     fn operating_on_with_path_args_absolute_dir_in_project_root() -> Result<()> {
-        let cwd = env::current_dir()?;
+        let cwd = cwd_utf8();
         let mut command = default_command();
         command.project_root = cwd.clone();
         command.invocation.path_args = PathArgs::AbsoluteDir;
 
         assert_eq!(
-            command.operating_on(&vec1![Path::new("file1")], &command.project_root)?,
+            command.operating_on(&vec1![Utf8Path::new("file1")], &command.project_root)?,
             vec![cwd.clone()],
         );
 
         let mut subdir = cwd;
         subdir.push("subdir");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("subdir/file2")], &command.project_root)?,
+            command.operating_on(&vec1![Utf8Path::new("subdir/file2")], &command.project_root)?,
             vec![subdir],
         );
 
@@ -1765,7 +1746,7 @@ mod tests {
     #[test]
     #[parallel]
     fn operating_on_with_path_args_absolute_dir_in_dir() -> Result<()> {
-        let cwd = env::current_dir()?;
+        let cwd = cwd_utf8();
         let mut command = default_command();
         command.project_root = cwd.clone();
         command.invocation.path_args = PathArgs::AbsoluteDir;
@@ -1774,14 +1755,14 @@ mod tests {
         in_dir.push("subdir");
 
         assert_eq!(
-            command.operating_on(&vec1![Path::new("file1")], &in_dir)?,
+            command.operating_on(&vec1![Utf8Path::new("file1")], &in_dir)?,
             vec![cwd.clone()],
         );
 
         let mut subdir = cwd;
         subdir.push("subdir");
         assert_eq!(
-            command.operating_on(&vec1![Path::new("subdir/file2")], &in_dir)?,
+            command.operating_on(&vec1![Utf8Path::new("subdir/file2")], &in_dir)?,
             vec![subdir],
         );
 
@@ -1794,10 +1775,10 @@ mod tests {
         let mut command = default_command();
         command.invocation.path_args = PathArgs::Dot;
 
-        let files = vec1![Path::new("file1"), Path::new("subdir/file2")];
+        let files = vec1![Utf8Path::new("file1"), Utf8Path::new("subdir/file2")];
         assert_eq!(
             command.operating_on(&files, &command.project_root)?,
-            vec![PathBuf::from(".")],
+            vec![Utf8PathBuf::from(".")],
         );
 
         Ok(())
@@ -1812,10 +1793,10 @@ mod tests {
         let mut in_dir = command.project_root.clone();
         in_dir.push("subdir");
 
-        let files = vec1![Path::new("file1"), Path::new("subdir/file2")];
+        let files = vec1![Utf8Path::new("file1"), Utf8Path::new("subdir/file2")];
         assert_eq!(
             command.operating_on(&files, &in_dir)?,
-            vec![PathBuf::from(".")],
+            vec![Utf8PathBuf::from(".")],
         );
 
         Ok(())
@@ -1827,8 +1808,8 @@ mod tests {
         let mut command = default_command();
         command.invocation.path_args = PathArgs::None;
 
-        let files = vec1![Path::new("file1"), Path::new("subdir/file2")];
-        let expect: Vec<PathBuf> = vec![];
+        let files = vec1![Utf8Path::new("file1"), Utf8Path::new("subdir/file2")];
+        let expect: Vec<Utf8PathBuf> = vec![];
         assert_eq!(command.operating_on(&files, &command.project_root)?, expect);
 
         Ok(())
@@ -1843,8 +1824,8 @@ mod tests {
         let mut in_dir = command.project_root.clone();
         in_dir.push("subdir");
 
-        let files = vec1![Path::new("file1"), Path::new("subdir/file2")];
-        let expect: Vec<PathBuf> = vec![];
+        let files = vec1![Utf8Path::new("file1"), Utf8Path::new("subdir/file2")];
+        let expect: Vec<Utf8PathBuf> = vec![];
         assert_eq!(command.operating_on(&files, &in_dir)?, expect);
 
         Ok(())
@@ -1860,7 +1841,7 @@ mod tests {
         let helper = TestHelper::new()?.with_git_repo()?;
         let mut file = helper.git_root();
         file.push("src/bar.rs");
-        let files = vec1![file.as_ref()];
+        let files = vec1![file.as_path()];
         let metadata = command
             .maybe_path_metadata_for(ActualInvoke::PerFile, &files)?
             .unwrap_or_else(|| unreachable!("Should always have metadata with Invoke::PerFile"));
@@ -1882,7 +1863,7 @@ mod tests {
         let helper = TestHelper::new()?.with_git_repo()?;
         let mut dir = helper.git_root();
         dir.push("src");
-        let files = vec1![dir.as_ref()];
+        let files = vec1![dir.as_path()];
         let metadata = command
             .maybe_path_metadata_for(ActualInvoke::PerFile, &files)?
             .unwrap_or_else(|| unreachable!("Should always have metadata with Invoke::PerFile"));
@@ -1890,11 +1871,7 @@ mod tests {
         for name in expect_files {
             let mut file = dir.clone();
             file.push(name);
-            assert!(
-                metadata.path_map.contains_key(&file),
-                "contains {}",
-                file.display(),
-            );
+            assert!(metadata.path_map.contains_key(&file), "contains {}", file,);
         }
         assert_eq!(metadata.path_map.len(), expect_files.len());
         assert_eq!(metadata.dir, Some(dir));
@@ -1908,8 +1885,8 @@ mod tests {
         let mut command = default_command();
         command.invocation.invoke = Invoke::Once;
 
-        let cwd = env::current_dir()?;
-        let files = vec1![cwd.as_ref()];
+        let cwd = cwd_utf8();
+        let files = vec1![cwd.as_path()];
         assert!(command
             .maybe_path_metadata_for(ActualInvoke::Once, &files)?
             .is_none());
@@ -1930,7 +1907,7 @@ mod tests {
         let helper = TestHelper::new()?.with_git_repo()?;
         let mut file = helper.git_root();
         file.push("src/main.rs");
-        let files = vec1![file.as_ref()];
+        let files = vec1![file.as_path()];
 
         let prev = command.maybe_path_metadata_for(ActualInvoke::PerFile, &files)?;
         assert!(prev.is_some());
@@ -1955,7 +1932,7 @@ mod tests {
         let helper = TestHelper::new()?.with_git_repo()?;
         let mut file = helper.git_root();
         file.push("src/main.rs");
-        let files = vec1![file.as_ref()];
+        let files = vec1![file.as_path()];
 
         let prev = command.maybe_path_metadata_for(ActualInvoke::PerFile, &files)?;
         assert!(prev.is_some());
@@ -1980,7 +1957,7 @@ mod tests {
         let helper = TestHelper::new()?.with_git_repo()?;
         let mut file = helper.git_root();
         file.push("src/main.rs");
-        let files = vec1![file.as_ref()];
+        let files = vec1![file.as_path()];
 
         let prev = command.maybe_path_metadata_for(ActualInvoke::PerFile, &files)?;
         assert!(prev.is_some());
@@ -2006,19 +1983,21 @@ mod tests {
             .build()?;
 
         let helper = TestHelper::new()?.with_git_repo()?;
+        let git_root = helper.git_root();
+        let all_files = helper.all_files();
         let mut files = vec![];
-        for path in helper.all_files() {
+        for path in &all_files {
             if path.starts_with("src/")
-                && path.to_str().unwrap().ends_with(".rs")
+                && path.as_str().ends_with(".rs")
                 && path.ancestors().count() == 3
             {
-                let mut file = helper.git_root();
+                let mut file = git_root.clone();
                 file.push(path);
                 files.push(file);
             }
         }
 
-        let files = Vec1::try_from(files.iter().map(|f| f.as_ref()).collect::<Vec<_>>()).unwrap();
+        let files = Vec1::try_from(files.iter().map(|f| f.as_path()).collect::<Vec<_>>()).unwrap();
         let prev = command.maybe_path_metadata_for(ActualInvoke::PerDir, &files)?;
         assert!(prev.is_some());
         let prev = prev.unwrap();
@@ -2029,7 +2008,7 @@ mod tests {
         );
         assert!(!command.paths_were_changed(prev.clone())?);
 
-        let mut file = helper.git_root();
+        let mut file = git_root;
         file.push("src/new.rs");
         fs::write(&file, "a new file")?;
         assert!(command.paths_were_changed(prev)?);
@@ -2048,19 +2027,21 @@ mod tests {
             .build()?;
 
         let helper = TestHelper::new()?.with_git_repo()?;
+        let git_root = helper.git_root();
+        let all_files = helper.all_files();
         let mut files = vec![];
-        for path in helper.all_files() {
+        for path in &all_files {
             if path.starts_with("src/")
-                && path.to_str().unwrap().ends_with(".rs")
+                && path.as_str().ends_with(".rs")
                 && path.ancestors().count() == 3
             {
-                let mut file = helper.git_root();
+                let mut file = git_root.clone();
                 file.push(path);
                 files.push(file);
             }
         }
 
-        let files = Vec1::try_from(files.iter().map(|f| f.as_ref()).collect::<Vec<_>>()).unwrap();
+        let files = Vec1::try_from(files.iter().map(|f| f.as_path()).collect::<Vec<_>>()).unwrap();
         let prev = command.maybe_path_metadata_for(ActualInvoke::PerDir, &files)?;
         assert!(prev.is_some());
         let prev = prev.unwrap();
@@ -2165,7 +2146,7 @@ mod tests {
         command.name = String::from("Test");
         command.invocation.invoke = actual_invoke.as_invoke();
         command.filter.include = include.iter().map(|i| i.to_string()).collect();
-        let paths: Vec1<&Path> = paths.iter1().map(Path::new).collect1();
+        let paths: Vec1<&Utf8Path> = paths.iter1().map(Utf8Path::new).collect1();
         assert_eq!(&command.paths_summary(actual_invoke, &paths), expect);
 
         Ok(())

--- a/precious-core/src/config.rs
+++ b/precious-core/src/config.rs
@@ -1,12 +1,9 @@
 use crate::command::{self, CommandType, Invoke, PathArgs, WorkingDir};
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 use serde::{de, de::Deserializer, Deserialize};
-use std::{
-    collections::HashMap,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, fs};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -85,8 +82,8 @@ pub struct Config {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub(crate) enum ConfigError {
-    #[error("File at {} cannot be read: {error:}", file.display())]
-    FileCannotBeRead { file: PathBuf, error: String },
+    #[error("File at {file} cannot be read: {error:}")]
+    FileCannotBeRead { file: Utf8PathBuf, error: String },
     #[error(r#"Cannot set invoke = "per-file" and path-args = "{path_args:}""#)]
     CannotInvokePerFileWithPathArgs { path_args: PathArgs },
     #[error(r#"Cannot set invoke = "per-dir" and path-args = "{path_args:}""#)]
@@ -173,7 +170,7 @@ where
                 ));
             }
 
-            Ok(Some(WorkingDir::ChdirTo(PathBuf::from(value))))
+            Ok(Some(WorkingDir::ChdirTo(Utf8PathBuf::from(value))))
         }
     }
 }
@@ -181,22 +178,22 @@ where
 const DEFAULT_LABEL: &str = "default";
 
 impl Config {
-    pub(crate) fn new(file: &Path) -> Result<Config> {
+    pub(crate) fn new(file: &Utf8Path) -> Result<Config> {
         let bytes = fs::read(file).map_err(|e| ConfigError::FileCannotBeRead {
-            file: file.to_path_buf(),
+            file: file.to_owned(),
             error: e.to_string(),
         })?;
 
         let content = String::from_utf8(bytes)
-            .with_context(|| format!("Config file at {} contains invalid UTF-8", file.display()))?;
+            .with_context(|| format!("Config file at {file} contains invalid UTF-8"))?;
 
         toml::from_str::<Config>(&content)
-            .with_context(|| format!("Failed to parse config file at {} as TOML", file.display()))
+            .with_context(|| format!("Failed to parse config file at {file} as TOML"))
     }
 
     pub(crate) fn into_tidy_commands(
         self,
-        project_root: &Path,
+        project_root: &Utf8Path,
         command: Option<&str>,
         label: Option<&str>,
     ) -> Result<Vec<command::Command>> {
@@ -205,7 +202,7 @@ impl Config {
 
     pub(crate) fn into_lint_commands(
         self,
-        project_root: &Path,
+        project_root: &Utf8Path,
         command: Option<&str>,
         label: Option<&str>,
     ) -> Result<Vec<command::Command>> {
@@ -214,7 +211,7 @@ impl Config {
 
     fn into_commands(
         self,
-        project_root: &Path,
+        project_root: &Utf8Path,
         command: Option<&str>,
         label: Option<&str>,
         typ: CommandType,
@@ -283,7 +280,7 @@ impl Config {
 }
 
 impl CommandConfig {
-    fn try_into_command(self, project_root: &Path, name: &str) -> Result<command::Command> {
+    fn try_into_command(self, project_root: &Utf8Path, name: &str) -> Result<command::Command> {
         let params = self
             .into_command_params(project_root, name)
             .with_context(|| format!(r#"Failed to build parameters for command "{name}""#))?;
@@ -294,7 +291,7 @@ impl CommandConfig {
 
     fn into_command_params(
         self,
-        project_root: &Path,
+        project_root: &Utf8Path,
         name: &str,
     ) -> Result<command::CommandParams> {
         let (invoke, working_dir, path_args) =
@@ -363,10 +360,10 @@ impl CommandConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use camino::{Utf8Path, Utf8PathBuf};
     use mitsein::prelude::*;
     use pretty_assertions::assert_eq;
     use serial_test::parallel;
-    use std::path::Path;
     use test_case::test_case;
 
     #[test]
@@ -542,14 +539,14 @@ mod tests {
     )]
     #[test_case(
         Invoke::PerDir,
-        WorkingDir::ChdirTo(PathBuf::from("foo")),
+        WorkingDir::ChdirTo(Utf8PathBuf::from("foo")),
         PathArgs::None,
         ConfigError::CannotInvokePerDirInRootWithPathArgs { path_args: PathArgs::None } ;
         r#"invoke = "per-dir" + working_dir.chdir-to = "foo" + path-args = "none""#
     )]
     #[test_case(
         Invoke::PerDir,
-        WorkingDir::ChdirTo(PathBuf::from("foo")),
+        WorkingDir::ChdirTo(Utf8PathBuf::from("foo")),
         PathArgs::Dot,
         ConfigError::CannotInvokePerDirInRootWithPathArgs { path_args: PathArgs::Dot } ;
         r#"invoke = "per-dir" + working_dir.chdir-to = "foo" + path-args = "dot""#
@@ -588,7 +585,7 @@ mod tests {
             ignore_stderr: vec![],
             labels: vec![],
         };
-        let res = config.try_into_command(Path::new("."), "some-linter");
+        let res = config.try_into_command(Utf8Path::new("."), "some-linter");
         let err = res.unwrap_err().downcast::<ConfigError>().unwrap();
         assert_eq!(err, expect_err);
 
@@ -691,20 +688,20 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(toml_text)?;
-        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        let commands = config.into_lint_commands(Utf8Path::new("."), None, None)?;
         assert_eq!(commands.len(), 1);
 
-        let files: Vec1<PathBuf> = vec1![
-            PathBuf::from("src/foo.js"),
-            PathBuf::from("src/bar.jsx"),
-            PathBuf::from("src/baz.rs"),
+        let files: Vec1<Utf8PathBuf> = vec1![
+            Utf8PathBuf::from("src/foo.js"),
+            Utf8PathBuf::from("src/bar.jsx"),
+            Utf8PathBuf::from("src/baz.rs"),
         ];
         let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
-        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        let mut included: Vec<&Utf8Path> = arg_sets.into_iter().flatten().collect();
         included.sort();
         assert_eq!(
             included,
-            vec![Path::new("src/bar.jsx"), Path::new("src/foo.js")]
+            vec![Utf8Path::new("src/bar.jsx"), Utf8Path::new("src/foo.js")]
         );
 
         Ok(())
@@ -727,24 +724,24 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(toml_text)?;
-        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        let commands = config.into_lint_commands(Utf8Path::new("."), None, None)?;
         assert_eq!(commands.len(), 1);
 
-        let files: Vec1<PathBuf> = vec1![
-            PathBuf::from("src/app.js"),
-            PathBuf::from("src/main.css"),
-            PathBuf::from("src/theme.scss"),
-            PathBuf::from("src/main.rs"),
+        let files: Vec1<Utf8PathBuf> = vec1![
+            Utf8PathBuf::from("src/app.js"),
+            Utf8PathBuf::from("src/main.css"),
+            Utf8PathBuf::from("src/theme.scss"),
+            Utf8PathBuf::from("src/main.rs"),
         ];
         let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
-        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        let mut included: Vec<&Utf8Path> = arg_sets.into_iter().flatten().collect();
         included.sort();
         assert_eq!(
             included,
             vec![
-                Path::new("src/app.js"),
-                Path::new("src/main.css"),
-                Path::new("src/theme.scss"),
+                Utf8Path::new("src/app.js"),
+                Utf8Path::new("src/main.css"),
+                Utf8Path::new("src/theme.scss"),
             ]
         );
 
@@ -768,18 +765,18 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(toml_text)?;
-        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        let commands = config.into_lint_commands(Utf8Path::new("."), None, None)?;
         assert_eq!(commands.len(), 1);
 
-        let files: Vec1<PathBuf> = vec1![
-            PathBuf::from("src/app.js"),
-            PathBuf::from("vendor/lib.js"),
-            PathBuf::from("generated/out.js"),
+        let files: Vec1<Utf8PathBuf> = vec1![
+            Utf8PathBuf::from("src/app.js"),
+            Utf8PathBuf::from("vendor/lib.js"),
+            Utf8PathBuf::from("generated/out.js"),
         ];
         let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
-        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        let mut included: Vec<&Utf8Path> = arg_sets.into_iter().flatten().collect();
         included.sort();
-        assert_eq!(included, vec![Path::new("src/app.js")]);
+        assert_eq!(included, vec![Utf8Path::new("src/app.js")]);
 
         Ok(())
     }
@@ -804,21 +801,21 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(toml_text)?;
-        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        let commands = config.into_lint_commands(Utf8Path::new("."), None, None)?;
         assert_eq!(commands.len(), 1);
 
-        let files: Vec1<PathBuf> = vec1![
-            PathBuf::from("src/app.js"),
-            PathBuf::from("src/app.ts"),
-            PathBuf::from("src/app.test.ts"),
-            PathBuf::from("vendor/lib.js"),
+        let files: Vec1<Utf8PathBuf> = vec1![
+            Utf8PathBuf::from("src/app.js"),
+            Utf8PathBuf::from("src/app.ts"),
+            Utf8PathBuf::from("src/app.test.ts"),
+            Utf8PathBuf::from("vendor/lib.js"),
         ];
         let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
-        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        let mut included: Vec<&Utf8Path> = arg_sets.into_iter().flatten().collect();
         included.sort();
         assert_eq!(
             included,
-            vec![Path::new("src/app.js"), Path::new("src/app.ts")]
+            vec![Utf8Path::new("src/app.js"), Utf8Path::new("src/app.ts")]
         );
 
         Ok(())
@@ -841,7 +838,7 @@ mod tests {
 
         let config: Config = toml::from_str(toml_text)?;
         let err = config
-            .into_lint_commands(Path::new("."), None, None)
+            .into_lint_commands(Utf8Path::new("."), None, None)
             .unwrap_err()
             .downcast::<ConfigError>()?;
         assert_eq!(
@@ -868,7 +865,7 @@ mod tests {
 
         let config: Config = toml::from_str(toml_text)?;
         let err = config
-            .into_lint_commands(Path::new("."), None, None)
+            .into_lint_commands(Utf8Path::new("."), None, None)
             .unwrap_err()
             .downcast::<ConfigError>()?;
         assert_eq!(
@@ -897,20 +894,20 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(toml_text)?;
-        let commands = config.into_lint_commands(Path::new("."), None, None)?;
+        let commands = config.into_lint_commands(Utf8Path::new("."), None, None)?;
         assert_eq!(commands.len(), 1);
 
-        let files: Vec1<PathBuf> = vec1![
-            PathBuf::from("src/lib.rs"),
-            PathBuf::from("src/main.rs"),
-            PathBuf::from("src/main.js"),
+        let files: Vec1<Utf8PathBuf> = vec1![
+            Utf8PathBuf::from("src/lib.rs"),
+            Utf8PathBuf::from("src/main.rs"),
+            Utf8PathBuf::from("src/main.js"),
         ];
         let (arg_sets, _) = commands[0].files_to_args_sets(&files)?;
-        let mut included: Vec<&Path> = arg_sets.into_iter().flatten().collect();
+        let mut included: Vec<&Utf8Path> = arg_sets.into_iter().flatten().collect();
         included.sort();
         assert_eq!(
             included,
-            vec![Path::new("src/lib.rs"), Path::new("src/main.rs")]
+            vec![Utf8Path::new("src/lib.rs"), Utf8Path::new("src/main.rs")]
         );
 
         Ok(())
@@ -936,7 +933,7 @@ mod tests {
 
         let config: Config = toml::from_str(toml_text)?;
         let err = config
-            .into_lint_commands(Path::new("."), Some("clippy"), None)
+            .into_lint_commands(Utf8Path::new("."), Some("clippy"), None)
             .unwrap_err()
             .downcast::<ConfigError>()?;
         assert_eq!(
@@ -970,7 +967,7 @@ mod tests {
 
         let config: Config = toml::from_str(toml_text)?;
         let err = config
-            .into_lint_commands(Path::new("."), None, Some("ci"))
+            .into_lint_commands(Utf8Path::new("."), None, Some("ci"))
             .unwrap_err()
             .downcast::<ConfigError>()?;
         assert_eq!(
@@ -997,7 +994,7 @@ mod tests {
 
         let config: Config = toml::from_str(toml_text)?;
         let err = config
-            .into_lint_commands(Path::new("."), None, None)
+            .into_lint_commands(Utf8Path::new("."), None, None)
             .unwrap_err()
             .downcast::<ConfigError>()?;
         assert_eq!(

--- a/precious-core/src/config_init.rs
+++ b/precious-core/src/config_init.rs
@@ -1,14 +1,13 @@
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::ValueEnum;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use log::debug;
 use std::{
     collections::{HashMap, HashSet},
-    env,
     fs::{create_dir_all, File},
     io::Write,
-    path::{Path, PathBuf},
 };
 use thiserror::Error;
 
@@ -24,7 +23,7 @@ pub(crate) struct Init {
 }
 
 pub(crate) struct ConfigInitFile {
-    pub(crate) path: PathBuf,
+    pub(crate) path: Utf8PathBuf,
     pub(crate) content: &'static str,
     pub(crate) is_executable: bool,
 }
@@ -47,7 +46,7 @@ pub(crate) enum InitComponent {
 #[derive(Debug, Error)]
 enum ConfigInitError {
     #[error("A file already exists at the given path: {path}")]
-    FileExists { path: PathBuf },
+    FileExists { path: Utf8PathBuf },
 }
 
 const GO_COMMANDS: [(&str, &str); 3] = [
@@ -222,12 +221,12 @@ pub(crate) fn go_init() -> Init {
         commands: &GO_COMMANDS,
         extra_files: vec![
             ConfigInitFile {
-                path: PathBuf::from("dev/bin/check-go-mod.sh"),
+                path: Utf8PathBuf::from("dev/bin/check-go-mod.sh"),
                 content: CHECK_GO_MOD,
                 is_executable: true,
             },
             ConfigInitFile {
-                path: PathBuf::from(".golangci.yml"),
+                path: Utf8PathBuf::from(".golangci.yml"),
                 content: GOLANGCI_YML,
                 is_executable: false,
             },
@@ -620,16 +619,16 @@ struct ConfigElements {
     excludes: HashSet<&'static str>,
     shared: IndexMap<&'static str, &'static [&'static str]>,
     commands: IndexMap<&'static str, &'static str>,
-    extra_files: HashMap<PathBuf, ConfigInitFile>,
+    extra_files: HashMap<Utf8PathBuf, ConfigInitFile>,
     tool_urls: IndexSet<&'static str>,
 }
 
 pub(crate) fn write_config_files(
     auto: bool,
     components: &[InitComponent],
-    path: &Path,
+    path: &Utf8Path,
+    cwd: &Utf8Path,
 ) -> Result<()> {
-    let cwd = env::current_dir().with_context(|| "Failed to get current working directory")?;
     if cwd.join(path).exists() {
         return Err(ConfigInitError::FileExists {
             path: path.to_owned(),
@@ -637,8 +636,8 @@ pub(crate) fn write_config_files(
         .into());
     }
 
-    let elements =
-        config_elements(auto, components).with_context(|| "Failed to generate config elements")?;
+    let elements = config_elements(auto, components, cwd)
+        .with_context(|| "Failed to generate config elements")?;
 
     let mut toml = excludes_toml(&elements.excludes);
 
@@ -655,13 +654,13 @@ pub(crate) fn write_config_files(
     toml.push_str(&commands_toml(elements.commands));
 
     println!();
-    println!("Writing {}", path.display());
+    println!("Writing {path}");
 
-    let mut precious_toml = File::create(path)
-        .with_context(|| format!("Failed to create config file at {}", path.display()))?;
+    let mut precious_toml =
+        File::create(path).with_context(|| format!("Failed to create config file at {path}"))?;
     precious_toml
         .write_all(toml.as_bytes())
-        .with_context(|| format!("Failed to write config data to {}", path.display()))?;
+        .with_context(|| format!("Failed to write config data to {path}"))?;
 
     write_extra_files(&elements.extra_files)
         .with_context(|| format!("Failed to write extra files for {components:?} components"))?;
@@ -676,14 +675,18 @@ pub(crate) fn write_config_files(
     Ok(())
 }
 
-fn config_elements(auto: bool, components: &[InitComponent]) -> Result<ConfigElements> {
+fn config_elements(
+    auto: bool,
+    components: &[InitComponent],
+    cwd: &Utf8Path,
+) -> Result<ConfigElements> {
     let mut excludes: HashSet<&'static str> = HashSet::new();
     let mut shared: IndexMap<&'static str, &'static [&'static str]> = IndexMap::new();
     let mut commands = IndexMap::new();
-    let mut extra_files = HashMap::new();
+    let mut extra_files: HashMap<Utf8PathBuf, ConfigInitFile> = HashMap::new();
     let mut tool_urls: IndexSet<&'static str> = IndexSet::new();
 
-    for l in auto_or_component(auto, components)? {
+    for l in auto_or_component(auto, components, cwd)? {
         let init = match l {
             InitComponent::Gitignore => gitignore_init(),
             InitComponent::Go => go_init(),
@@ -719,40 +722,39 @@ fn config_elements(auto: bool, components: &[InitComponent]) -> Result<ConfigEle
     })
 }
 
-fn auto_or_component(auto: bool, components: &[InitComponent]) -> Result<Vec<InitComponent>> {
+fn auto_or_component(
+    auto: bool,
+    components: &[InitComponent],
+    cwd: &Utf8Path,
+) -> Result<Vec<InitComponent>> {
     if !auto {
         return Ok(components.to_vec());
     }
 
     let mut components: HashSet<InitComponent> = HashSet::new();
-    let cwd =
-        env::current_dir().context("Failed to get current working directory for auto detection")?;
-    debug!(
-        "Looking at all files under {} to determine which components to include.",
-        cwd.display(),
-    );
+    debug!("Looking at all files under {cwd} to determine which components to include.");
 
-    for result in ignore::WalkBuilder::new(&cwd).hidden(false).build() {
-        let entry =
-            result.with_context(|| format!("Failed to walk directory {}", cwd.display()))?;
+    for result in ignore::WalkBuilder::new(cwd).hidden(false).build() {
+        let entry = result.with_context(|| format!("Failed to walk directory {cwd}"))?;
         // The only time this is `None` is when the entry is for stdin, which
         // will never happen here.
         if !entry.file_type().unwrap().is_file() {
             continue;
         }
 
-        if entry.file_name() == ".gitignore" {
+        let path = Utf8PathBuf::from_path_buf(entry.into_path()).map_err(|raw| {
+            crate::paths::utf8::NonUtf8PathError {
+                raw,
+                source: crate::paths::utf8::NonUtf8Source::FilesystemWalk,
+            }
+        })?;
+
+        if path.file_name() == Some(".gitignore") {
             components.insert(InitComponent::Gitignore);
             continue;
         }
 
-        let component = match entry
-            .path()
-            .extension()
-            .unwrap_or_default()
-            .to_str()
-            .unwrap_or_default()
-        {
+        let component = match path.extension().unwrap_or_default() {
             "go" => InitComponent::Go,
             "md" => InitComponent::Markdown,
             "pl" | "pm" => InitComponent::Perl,
@@ -765,11 +767,7 @@ fn auto_or_component(auto: bool, components: &[InitComponent]) -> Result<Vec<Ini
             "yml" | "yaml" => InitComponent::Yaml,
             _ => continue,
         };
-        debug!(
-            "File {} matches component {:?}",
-            entry.path().display(),
-            component,
-        );
+        debug!("File {path} matches component {component:?}");
         components.insert(component);
     }
 
@@ -829,7 +827,7 @@ fn commands_toml(commands: IndexMap<&str, &str>) -> String {
     command_strs.join("\n")
 }
 
-fn write_extra_files(extra_files: &HashMap<PathBuf, ConfigInitFile>) -> Result<()> {
+fn write_extra_files(extra_files: &HashMap<Utf8PathBuf, ConfigInitFile>) -> Result<()> {
     if extra_files.is_empty() {
         return Ok(());
     }
@@ -841,7 +839,7 @@ fn write_extra_files(extra_files: &HashMap<PathBuf, ConfigInitFile>) -> Result<(
     let paths = extra_files.keys().sorted().collect::<Vec<_>>();
 
     for p in paths {
-        print!("{} ...", p.display());
+        print!("{p} ...");
         if p.exists() {
             println!("  already exists, skipping - delete this file if you want to regenerate it");
             continue;
@@ -850,24 +848,22 @@ fn write_extra_files(extra_files: &HashMap<PathBuf, ConfigInitFile>) -> Result<(
 
         if let Some(parent) = p.parent() {
             create_dir_all(parent)
-                .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+                .with_context(|| format!("Failed to create directory {parent}"))?;
         }
-        let mut file =
-            File::create(p).with_context(|| format!("Failed to create file {}", p.display()))?;
+        let mut file = File::create(p).with_context(|| format!("Failed to create file {p}"))?;
         let f = extra_files.get(p).unwrap();
         file.write_all(f.content.trim_start().as_bytes())
-            .with_context(|| format!("Failed to write content to file {}", p.display()))?;
+            .with_context(|| format!("Failed to write content to file {p}"))?;
 
         #[cfg(unix)]
         if f.is_executable {
             let mut perms = file
                 .metadata()
-                .with_context(|| format!("Failed to get metadata for {}", p.display()))?
+                .with_context(|| format!("Failed to get metadata for {p}"))?
                 .permissions();
             perms.set_mode(0o755);
-            file.set_permissions(perms).with_context(|| {
-                format!("Failed to set executable permissions on {}", p.display())
-            })?;
+            file.set_permissions(perms)
+                .with_context(|| format!("Failed to set executable permissions on {p}"))?;
         }
     }
 

--- a/precious-core/src/paths.rs
+++ b/precious-core/src/paths.rs
@@ -1,3 +1,4 @@
 pub mod finder;
 pub mod matcher;
 pub mod mode;
+pub mod utf8;

--- a/precious-core/src/paths/finder.rs
+++ b/precious-core/src/paths/finder.rs
@@ -2,28 +2,25 @@ use crate::{
     paths::{
         matcher::{Matcher, MatcherBuilder},
         mode::Mode,
+        utf8::{NonUtf8PathError, NonUtf8Source},
     },
     vcs,
 };
 use anyhow::{Context, Result};
-use clean_path::Clean;
+use camino::{Utf8Path, Utf8PathBuf};
 use log::{debug, error};
 use mitsein::prelude::*;
 use precious_helpers::exec::Exec;
 use regex::Regex;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    sync::LazyLock,
-};
+use std::sync::LazyLock;
 use thiserror::Error;
 
 #[derive(Debug)]
 pub struct Finder {
     mode: Mode,
-    project_root: PathBuf,
-    git_root: Option<PathBuf>,
-    cwd: PathBuf,
+    project_root: Utf8PathBuf,
+    git_root: Option<Utf8PathBuf>,
+    cwd: Utf8PathBuf,
     exclude_globs: Vec<String>,
     stashed: bool,
 }
@@ -47,14 +44,17 @@ pub enum FinderError {
     )]
     AllPathsWereExcluded,
 
-    #[error("Path passed on the command line does not exist: {}", path.display())]
-    NonExistentPathOnCli { path: PathBuf },
+    #[error("Path passed on the command line does not exist: {path}")]
+    NonExistentPathOnCli { path: Utf8PathBuf },
 
     #[error(r#"Could not determine the repo root by running "git rev-parse --show-toplevel""#)]
     CouldNotDetermineRepoRoot,
 
-    #[error(r#"The path "{}" does not contain "{}" as a prefix"#, path.display(), prefix.display())]
-    PrefixNotFound { path: PathBuf, prefix: PathBuf },
+    #[error(r#"The path "{path}" does not contain "{prefix}" as a prefix"#)]
+    PrefixNotFound {
+        path: Utf8PathBuf,
+        prefix: Utf8PathBuf,
+    },
 }
 
 static KEEP_INDEX_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(".*").unwrap());
@@ -62,16 +62,13 @@ static KEEP_INDEX_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(".*").unwrap
 impl Finder {
     pub fn new(
         mode: Mode,
-        project_root: &Path,
-        cwd: PathBuf,
+        project_root: &Utf8Path,
+        cwd: Utf8PathBuf,
         exclude_globs: Vec<String>,
     ) -> Result<Finder> {
-        let canonical_root = fs::canonicalize(project_root).with_context(|| {
-            format!(
-                "Failed to canonicalize project root path {}",
-                project_root.display()
-            )
-        })?;
+        let canonical_root = project_root
+            .canonicalize_utf8()
+            .with_context(|| format!("Failed to canonicalize project root path {project_root}"))?;
 
         Ok(Finder {
             mode,
@@ -83,9 +80,7 @@ impl Finder {
         })
     }
 
-    // Fixing this will cascade through the code base. I'll do it later (maybe).
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn files(&mut self, cli_paths: Vec<PathBuf>) -> Result<Option<Vec1<PathBuf>>> {
+    pub fn files(&mut self, cli_paths: &[Utf8PathBuf]) -> Result<Option<Vec1<Utf8PathBuf>>> {
         match self.mode {
             Mode::FromCli => (),
             Mode::All
@@ -105,7 +100,7 @@ impl Finder {
         let mut files = match self.mode.clone() {
             Mode::All => self.all_files().context("Failed to get all files")?,
             Mode::FromCli => self
-                .files_from_cli(cli_paths.clone())
+                .files_from_cli(cli_paths)
                 .context("Failed to get files from command line")?,
             Mode::GitModified => self
                 .git_modified_files()
@@ -128,14 +123,14 @@ impl Finder {
                 Mode::FromCli => {
                     let err = if cli_paths.len() == 1 {
                         FinderError::CLIPathsWereExcludedSingular {
-                            path: cli_paths[0].display().to_string(),
+                            path: cli_paths[0].as_str().to_string(),
                         }
                     } else {
                         FinderError::CLIPathsWereExcludedMultiple {
-                            paths: Self::truncate_path_list(&cli_paths),
+                            paths: Self::truncate_path_list(cli_paths),
                         }
                     };
-                    return Err(err.into());
+                    Err(err.into())
                 }
                 Mode::All => Err(FinderError::AllPathsWereExcluded {}.into()),
             };
@@ -148,7 +143,7 @@ impl Finder {
         ))
     }
 
-    fn git_root(&mut self) -> Result<PathBuf> {
+    fn git_root(&mut self) -> Result<Utf8PathBuf> {
         if let Some(r) = &self.git_root {
             return Ok(r.clone());
         }
@@ -162,29 +157,48 @@ impl Finder {
             .run()
             .context("Failed to run git rev-parse to determine repository root")?;
 
-        let stdout = res
-            .stdout
+        let bytes = res
+            .stdout_bytes
+            .as_deref()
             .ok_or(FinderError::CouldNotDetermineRepoRoot)
             .context("git rev-parse did not produce output")?;
-        self.git_root = Some(PathBuf::from(stdout.trim()));
+        // git rev-parse appends exactly one line terminator: \n on unix, \r\n
+        // on Windows. Strip that one terminator — never trim spaces, tabs, or
+        // repeated newlines, all of which are valid trailing characters in a
+        // path.
+        let trimmed = bytes
+            .strip_suffix(b"\r\n")
+            .or_else(|| bytes.strip_suffix(b"\n"))
+            .unwrap_or(bytes);
+        let s = std::str::from_utf8(trimmed).map_err(|_| NonUtf8PathError {
+            raw: crate::paths::utf8::bytes_to_pathbuf(trimmed),
+            source: NonUtf8Source::GitRoot,
+        })?;
+        self.git_root = Some(Utf8PathBuf::from(s));
 
-        Ok(self.git_root.clone().unwrap())
+        Ok(self
+            .git_root
+            .clone()
+            .expect("we know this is Some - look up a couple lines"))
     }
 
-    fn all_files(&self) -> Result<Vec<PathBuf>> {
-        debug!("Getting all files under {}", self.project_root.display());
-        self.walkdir_files(self.project_root.as_path())
+    fn all_files(&self) -> Result<Vec<Utf8PathBuf>> {
+        debug!("Getting all files under {}", self.project_root);
+        self.walkdir_files(&self.project_root)
     }
 
-    fn files_from_cli(&self, cli_paths: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    fn files_from_cli(&self, cli_paths: &[Utf8PathBuf]) -> Result<Vec<Utf8PathBuf>> {
         debug!("Using the list of files passed from the command line");
         let exclude_matcher = self.exclude_matcher()?;
 
-        let mut files: Vec<PathBuf> = vec![];
+        let mut files: Vec<Utf8PathBuf> = vec![];
         for rel_to_cwd in cli_paths {
-            let full = self.cwd.clone().join(rel_to_cwd.clone());
+            let full = self.cwd.join(rel_to_cwd);
             if !full.exists() {
-                return Err(FinderError::NonExistentPathOnCli { path: rel_to_cwd }.into());
+                return Err(FinderError::NonExistentPathOnCli {
+                    path: rel_to_cwd.clone(),
+                }
+                .into());
             }
 
             let rel_to_root = self.path_relative_to_project_root(&full)?;
@@ -203,15 +217,27 @@ impl Finder {
         Ok(files)
     }
 
-    fn git_modified_files(&mut self) -> Result<Vec<PathBuf>> {
+    fn git_modified_files(&mut self) -> Result<Vec<Utf8PathBuf>> {
         debug!("Getting modified files according to git");
-        self.files_from_git(vec!["diff", "--name-only", "--diff-filter=ACM", "HEAD"])
+        self.files_from_git(vec![
+            "diff",
+            "--name-only",
+            "-z",
+            "--diff-filter=ACM",
+            "HEAD",
+        ])
     }
 
-    fn git_staged_files(&mut self) -> Result<Vec<PathBuf>> {
+    fn git_staged_files(&mut self) -> Result<Vec<Utf8PathBuf>> {
         debug!("Getting staged files according to git");
         self.maybe_git_stash()?;
-        self.files_from_git(vec!["diff", "--cached", "--name-only", "--diff-filter=ACM"])
+        self.files_from_git(vec![
+            "diff",
+            "--cached",
+            "--name-only",
+            "-z",
+            "--diff-filter=ACM",
+        ])
     }
 
     fn maybe_git_stash(&mut self) -> Result<()> {
@@ -239,12 +265,18 @@ impl Finder {
         Ok(())
     }
 
-    fn git_modified_since(&mut self, since: &str) -> Result<Vec<PathBuf>> {
+    fn git_modified_since(&mut self, since: &str) -> Result<Vec<Utf8PathBuf>> {
         let since_dot = format!("{since:}...");
-        self.files_from_git(vec!["diff", "--name-only", "--diff-filter=ACM", &since_dot])
+        self.files_from_git(vec![
+            "diff",
+            "--name-only",
+            "-z",
+            "--diff-filter=ACM",
+            &since_dot,
+        ])
     }
 
-    fn walkdir_files(&self, root: &Path) -> Result<Vec<PathBuf>> {
+    fn walkdir_files(&self, root: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
         let mut exclude_globs = ignore::overrides::OverrideBuilder::new(root);
         for d in vcs::DIRS {
             exclude_globs
@@ -256,7 +288,7 @@ impl Finder {
             .build()
             .context("Failed to build directory override patterns")?;
 
-        let mut files: Vec<PathBuf> = vec![];
+        let mut files: Vec<Utf8PathBuf> = vec![];
         for result in ignore::WalkBuilder::new(root)
             .hidden(false)
             .overrides(overrides)
@@ -264,14 +296,18 @@ impl Finder {
         {
             match result {
                 Ok(ent) => {
-                    if ent.path().is_dir() {
+                    let p = ent.into_path();
+                    let utf8 = Utf8PathBuf::from_path_buf(p).map_err(|raw| NonUtf8PathError {
+                        raw,
+                        source: NonUtf8Source::FilesystemWalk,
+                    })?;
+                    if utf8.is_dir() {
                         continue;
                     }
-                    files.push(ent.into_path());
+                    files.push(utf8);
                 }
                 Err(e) => {
-                    return Err(e)
-                        .with_context(|| format!("Failed to walk directory {}", root.display()))?
+                    return Err(e).with_context(|| format!("Failed to walk directory {root}"))?
                 }
             }
         }
@@ -287,7 +323,7 @@ impl Finder {
             .collect::<Vec<_>>())
     }
 
-    fn files_from_git(&mut self, args: Vec<&str>) -> Result<Vec<PathBuf>> {
+    fn files_from_git(&mut self, args: Vec<&str>) -> Result<Vec<Utf8PathBuf>> {
         let git_root = self
             .git_root()
             .context("Failed to determine git root while getting file list")?;
@@ -303,35 +339,37 @@ impl Finder {
             .exclude_matcher()
             .context("Failed to build exclude matcher for git files")?;
 
-        match output.stdout {
-            Some(s) => Ok(
-                // In the common case where the git repo root and project root
-                // are the same, this isn't necessary, because git will give
-                // us paths relative to the project root. But if the precious
-                // root _isn't_ the git root, we need to get the path relative
-                // to the project root, not the repo root.
-                self.paths_relative_to_project_root(
-                    &git_root,
-                    s.lines()
-                        .filter_map(|rel| {
-                            let pb = PathBuf::from(rel);
-                            if exclude_matcher.path_matches(&pb, false) {
-                                return None;
-                            }
-
-                            let mut f = git_root.clone();
-                            f.push(&pb);
-                            if !f.exists() {
-                                debug!(
-                                    "The staged file at {rel:} (abs path {}) was deleted so it will be ignored.",f.display(),
-                                );
-                                return None;
-                            }
-                            Some(f)
-                        })
-                        .collect(),
-                )?,
-            ),
+        match output.stdout_bytes.as_deref() {
+            Some(bytes) => {
+                // In the common case where the git repo root and project root are the same, this
+                // isn't necessary, because git will give us paths relative to the project root. But
+                // if the precious root _isn't_ the git root, we need to get the path relative to
+                // the project root, not the repo root.
+                let mut paths: Vec<Utf8PathBuf> = Vec::new();
+                for raw in bytes.split(|b| *b == 0).filter(|s| !s.is_empty()) {
+                    let Ok(s) = std::str::from_utf8(raw) else {
+                        return Err(NonUtf8PathError {
+                            raw: crate::paths::utf8::bytes_to_pathbuf(raw),
+                            source: NonUtf8Source::GitDiff,
+                        }
+                        .into());
+                    };
+                    let rel = Utf8PathBuf::from(s);
+                    if exclude_matcher.path_matches(&rel, false) {
+                        continue;
+                    }
+                    let mut f = git_root.clone();
+                    f.push(&rel);
+                    if !f.exists() {
+                        debug!(
+                            "The staged file at {rel} (abs path {f}) was deleted so it will be ignored.",
+                        );
+                        continue;
+                    }
+                    paths.push(f);
+                }
+                Ok(self.paths_relative_to_project_root(&git_root, paths)?)
+            }
             None => Ok(vec![]),
         }
     }
@@ -355,10 +393,10 @@ impl Finder {
         // This is the root to which the given paths are relative. This might
         // be the project root or it might be the git root, which are not
         // guaranteed to be the same thing.
-        path_root: &Path,
-        paths: Vec<PathBuf>,
-    ) -> Result<Vec<PathBuf>> {
-        let mut relative: Vec<PathBuf> = vec![];
+        path_root: &Utf8Path,
+        paths: Vec<Utf8PathBuf>,
+    ) -> Result<Vec<Utf8PathBuf>> {
+        let mut relative: Vec<Utf8PathBuf> = vec![];
         for mut f in paths {
             if !f.is_absolute() {
                 f = path_root.join(f);
@@ -370,38 +408,32 @@ impl Finder {
         Ok(relative)
     }
 
-    fn path_relative_to_project_root(&self, path: &Path) -> Result<PathBuf> {
-        // If the directory given is just "." then the first clean() removes
-        // that and we then strip the prefix, leaving an empty string. The
-        // second clean turns that back into ".".
-        let canonical = fs::canonicalize(path)
-            .with_context(|| format!("Failed to canonicalize path {}", path.display()))?
-            .clean();
+    fn path_relative_to_project_root(&self, path: &Utf8Path) -> Result<Utf8PathBuf> {
+        let canonical = path
+            .canonicalize_utf8()
+            .with_context(|| format!("Failed to canonicalize path {path}"))?;
 
-        Ok(canonical
-            .strip_prefix(&self.project_root)
-            .map_err(|_| {
-                anyhow::anyhow!(FinderError::PrefixNotFound {
-                    path: path.to_path_buf(),
-                    prefix: self.project_root.clone(),
-                })
-            })
-            .with_context(|| {
-                format!(
-                    "Failed to make path {} relative to project root {}",
-                    path.display(),
-                    self.project_root.display()
-                )
-            })?
-            .to_path_buf()
-            .clean())
+        let stripped = canonical.strip_prefix(&self.project_root).map_err(|_| {
+            FinderError::PrefixNotFound {
+                path: path.to_path_buf(),
+                prefix: self.project_root.clone(),
+            }
+        })?;
+
+        // When the input canonicalizes to the project root itself, strip_prefix yields an empty
+        // path. Downstream code expects a non-empty value, so return "." in that case.
+        if stripped.as_str().is_empty() {
+            Ok(Utf8PathBuf::from("."))
+        } else {
+            Ok(stripped.to_path_buf())
+        }
     }
 
-    fn truncate_path_list(cli_paths: &[PathBuf]) -> String {
+    fn truncate_path_list(cli_paths: &[Utf8PathBuf]) -> String {
         let is_truncated = cli_paths.len() > 3;
         let truncated = cli_paths
             .iter()
-            .map(|p| p.display().to_string())
+            .map(|p| p.as_str().to_string())
             .take(3)
             .collect::<Vec<_>>()
             .join(", ");
@@ -439,24 +471,25 @@ impl Drop for Finder {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use camino::Utf8PathBuf;
     use itertools::Itertools;
     use precious_testhelper as testhelper;
     use pretty_assertions::assert_eq;
     use serial_test::parallel;
     use std::fs;
 
-    fn new_finder(mode: Mode, root: PathBuf) -> Result<Finder> {
+    fn new_finder(mode: Mode, root: Utf8PathBuf) -> Result<Finder> {
         new_finder_with_excludes(mode, root.clone(), root, vec![])
     }
 
-    fn new_finder_with_cwd(mode: Mode, root: PathBuf, cwd: PathBuf) -> Result<Finder> {
+    fn new_finder_with_cwd(mode: Mode, root: Utf8PathBuf, cwd: Utf8PathBuf) -> Result<Finder> {
         new_finder_with_excludes(mode, root, cwd, vec![])
     }
 
     fn new_finder_with_excludes(
         mode: Mode,
-        root: PathBuf,
-        cwd: PathBuf,
+        root: Utf8PathBuf,
+        cwd: Utf8PathBuf,
         exclude: Vec<String>,
     ) -> Result<Finder> {
         Finder::new(mode, &root, cwd, exclude)
@@ -483,13 +516,36 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(unix)]
+    #[test]
+    #[parallel]
+    fn all_mode_errors_on_non_utf8_filename() -> Result<()> {
+        use crate::paths::utf8::{NonUtf8PathError, NonUtf8Source};
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let helper = testhelper::TestHelper::new()?.with_git_repo()?;
+        let bad_name = OsStr::from_bytes(b"data\xff.bin");
+        let mut full = helper.precious_root().into_std_path_buf();
+        full.push(bad_name);
+        fs::write(&full, b"contents")?;
+
+        let mut finder = new_finder(Mode::All, helper.precious_root())?;
+        let err = finder.files(&[]).expect_err("expected non-UTF-8 error");
+        let downcast = err
+            .downcast_ref::<NonUtf8PathError>()
+            .expect("expected NonUtf8PathError");
+        assert_eq!(downcast.source, NonUtf8Source::FilesystemWalk);
+        Ok(())
+    }
+
     #[test]
     #[parallel]
     fn all_mode() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
 
         let mut finder = new_finder(Mode::All, helper.precious_root())?;
-        assert_eq!(finder.files(vec![])?, Some(helper.all_files1()));
+        assert_eq!(finder.files(&[])?, Some(helper.all_files1()));
         Ok(())
     }
 
@@ -501,7 +557,7 @@ mod tests {
         cwd.push("src");
 
         let mut finder = new_finder_with_cwd(Mode::All, helper.precious_root(), cwd)?;
-        assert_eq!(finder.files(vec![])?, Some(helper.all_files1()));
+        assert_eq!(finder.files(&[])?, Some(helper.all_files1()));
         Ok(())
     }
 
@@ -509,14 +565,21 @@ mod tests {
     #[parallel]
     fn all_mode_with_gitignore() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        let mut gitignores = helper.add_gitignore_files()?;
-        let mut expect = testhelper::TestHelper::non_ignored_files();
+        let mut gitignores: Vec<Utf8PathBuf> = helper
+            .add_gitignore_files()?
+            .into_iter()
+            .map(|p| Utf8PathBuf::try_from(p).expect("gitignore file is valid UTF-8"))
+            .collect();
+        let mut expect = testhelper::TestHelper::non_ignored_files()
+            .into_iter()
+            .map(|p| Utf8PathBuf::try_from(p).expect("non-ignored file is valid UTF-8"))
+            .collect::<Vec<_>>();
         expect.append(&mut gitignores);
         expect.sort();
         let expect = Vec1::try_from(expect).unwrap();
 
         let mut finder = new_finder(Mode::All, helper.precious_root())?;
-        assert_eq!(finder.files(vec![])?, Some(expect));
+        assert_eq!(finder.files(&[])?, Some(expect));
         Ok(())
     }
 
@@ -524,14 +587,14 @@ mod tests {
     #[parallel]
     fn all_mode_with_excluded_files() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "new content")?;
         let mut finder = new_finder_with_excludes(
             Mode::All,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(helper.all_files1()));
+        assert_eq!(finder.files(&[])?, Some(helper.all_files1()));
         Ok(())
     }
 
@@ -539,14 +602,14 @@ mod tests {
     #[parallel]
     fn all_mode_with_excluded_files_bare_dir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "new content")?;
         let mut finder = new_finder_with_excludes(
             Mode::All,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(helper.all_files1()));
+        assert_eq!(finder.files(&[])?, Some(helper.all_files1()));
         Ok(())
     }
 
@@ -555,7 +618,7 @@ mod tests {
     fn git_modified_mode_empty() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let mut finder = new_finder(Mode::GitModified, helper.precious_root())?;
-        let res = finder.files(vec![]);
+        let res = finder.files(&[]);
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
         Ok(())
@@ -567,7 +630,7 @@ mod tests {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
         let mut finder = new_finder(Mode::GitModified, helper.precious_root())?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -579,7 +642,7 @@ mod tests {
         let mut cwd = helper.precious_root();
         cwd.push("src");
         let mut finder = new_finder_with_cwd(Mode::GitModified, helper.precious_root(), cwd)?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -587,7 +650,7 @@ mod tests {
     #[parallel]
     fn git_modified_mode_with_changes_all_excluded() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
 
         let mut finder = new_finder_with_excludes(
@@ -596,7 +659,7 @@ mod tests {
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, None);
+        assert_eq!(finder.files(&[])?, None);
         Ok(())
     }
 
@@ -604,19 +667,19 @@ mod tests {
     #[parallel]
     fn git_modified_mode_with_excluded_files() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         helper.commit_all()?;
 
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "new content")?;
         let mut finder = new_finder_with_excludes(
             Mode::GitModified,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -624,19 +687,19 @@ mod tests {
     #[parallel]
     fn git_modified_mode_with_excluded_files_bare_dir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         helper.commit_all()?;
 
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "new content")?;
         let mut finder = new_finder_with_excludes(
             Mode::GitModified,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -644,12 +707,12 @@ mod tests {
     #[parallel]
     fn git_modified_mode_with_excluded_files_in_subdir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         helper.commit_all()?;
 
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "new content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "new content")?;
         let mut cwd = helper.precious_root();
         cwd.push("src");
         let mut finder = new_finder_with_excludes(
@@ -658,7 +721,7 @@ mod tests {
             cwd,
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -672,7 +735,7 @@ mod tests {
         let mut project_root = helper.git_root();
         project_root.push("subdir");
         let mut finder = new_finder(Mode::GitModified, project_root)?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -681,9 +744,10 @@ mod tests {
     fn git_modified_mode_includes_staged() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.stage_some(&[&modified[0]])?;
+        let first = modified[0].clone();
+        helper.stage_some(&[first.as_std_path()])?;
         let mut finder = new_finder(Mode::GitModified, helper.precious_root())?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -692,7 +756,7 @@ mod tests {
     fn git_staged_mode_empty() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let mut finder = new_finder(Mode::GitStaged, helper.precious_root())?;
-        let res = finder.files(vec![]);
+        let res = finder.files(&[]);
         assert!(res.is_ok());
         assert!(res.unwrap().is_none());
         Ok(())
@@ -706,7 +770,7 @@ mod tests {
 
         {
             let mut finder = new_finder(Mode::GitStaged, helper.precious_root())?;
-            let res = finder.files(vec![]);
+            let res = finder.files(&[]);
             assert!(res.is_ok());
             assert!(res.unwrap().is_none());
         }
@@ -714,7 +778,7 @@ mod tests {
         {
             let mut finder = new_finder(Mode::GitStaged, helper.precious_root())?;
             helper.stage_all()?;
-            assert_eq!(finder.files(vec![])?, Some(modified));
+            assert_eq!(finder.files(&[])?, Some(modified));
         }
         Ok(())
     }
@@ -731,7 +795,7 @@ mod tests {
         {
             let mut finder =
                 new_finder_with_cwd(Mode::GitStaged, helper.precious_root(), cwd.clone())?;
-            let res = finder.files(vec![]);
+            let res = finder.files(&[]);
             assert!(res.is_ok());
             assert!(res.unwrap().is_none());
         }
@@ -739,7 +803,7 @@ mod tests {
         {
             let mut finder = new_finder_with_cwd(Mode::GitStaged, helper.precious_root(), cwd)?;
             helper.stage_all()?;
-            assert_eq!(finder.files(vec![])?, Some(modified));
+            assert_eq!(finder.files(&[])?, Some(modified));
         }
         Ok(())
     }
@@ -748,7 +812,7 @@ mod tests {
     #[parallel]
     fn git_staged_mode_with_changes_all_excluded() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
 
         let mut finder = new_finder_with_excludes(
@@ -757,7 +821,7 @@ mod tests {
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, None);
+        assert_eq!(finder.files(&[])?, None);
         Ok(())
     }
 
@@ -766,7 +830,7 @@ mod tests {
     fn git_staged_mode_with_excluded_files() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         let mut finder = new_finder_with_excludes(
             Mode::GitStaged,
@@ -774,7 +838,7 @@ mod tests {
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -783,7 +847,7 @@ mod tests {
     fn git_staged_mode_with_excluded_files_bare_dir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         let mut finder = new_finder_with_excludes(
             Mode::GitStaged,
@@ -791,7 +855,7 @@ mod tests {
             helper.precious_root(),
             vec!["vendor".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -800,7 +864,7 @@ mod tests {
     fn git_staged_mode_with_excluded_files_in_subdir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         helper.stage_all()?;
         let mut cwd = helper.precious_root();
         cwd.push("src");
@@ -810,7 +874,7 @@ mod tests {
             cwd,
             vec!["vendor/**/*".to_string()],
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -821,14 +885,14 @@ mod tests {
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
         helper.stage_all()?;
         let unstaged = "tests/data/bar.txt";
-        helper.write_file(PathBuf::from(unstaged), "new content")?;
+        helper.write_file(Utf8PathBuf::from(unstaged), "new content")?;
 
         #[cfg(not(target_os = "windows"))]
         set_up_post_checkout_hook(&helper)?;
 
         {
             let mut finder = new_finder(Mode::GitStagedWithStash, helper.precious_root())?;
-            assert_eq!(finder.files(vec![])?, Some(modified));
+            assert_eq!(finder.files(&[])?, Some(modified));
             assert_eq!(
                 String::from_utf8(fs::read(helper.precious_root().join(unstaged))?)?,
                 String::from("some text"),
@@ -854,7 +918,7 @@ mod tests {
     fn git_staged_mode_with_stash_merge_stash() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
 
-        let file = Path::new("merge-conflict-here");
+        let file = Utf8Path::new("merge-conflict-here");
         helper.write_file(file, "line 1\nline 2\n")?;
         helper.stage_all()?;
         helper.commit_all()?;
@@ -874,8 +938,8 @@ mod tests {
 
         let mut finder = new_finder(Mode::GitStaged, helper.precious_root())?;
         assert_eq!(
-            finder.files(vec![])?,
-            Some(vec1![PathBuf::from("merge-conflict-here")]),
+            finder.files(&[])?,
+            Some(vec1![Utf8PathBuf::from("merge-conflict-here")]),
         );
         assert!(!finder.stashed);
         Ok(())
@@ -887,13 +951,11 @@ mod tests {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
         let mut modified = helper.modify_files()?;
         helper.stage_all()?;
-        helper.delete_file(modified.remove(0))?;
+        let first = modified.remove(0);
+        helper.delete_file(&first)?;
 
         let mut finder = new_finder(Mode::GitStaged, helper.precious_root())?;
-        assert_eq!(
-            finder.files(vec![])?,
-            Some(Vec1::try_from(modified).unwrap())
-        );
+        assert_eq!(finder.files(&[])?, Some(Vec1::try_from(modified).unwrap()));
         Ok(())
     }
 
@@ -909,7 +971,7 @@ mod tests {
             Mode::GitDiffFrom("master".to_string()),
             helper.precious_root(),
         )?;
-        assert_eq!(finder.files(vec![])?, None);
+        assert_eq!(finder.files(&[])?, None);
 
         let modified = Vec1::try_from(helper.modify_files()?).unwrap();
         helper.commit_all()?;
@@ -918,7 +980,7 @@ mod tests {
             Mode::GitDiffFrom("master".to_string()),
             helper.precious_root(),
         )?;
-        assert_eq!(finder.files(vec![])?, Some(modified));
+        assert_eq!(finder.files(&[])?, Some(modified));
         Ok(())
     }
 
@@ -934,7 +996,7 @@ mod tests {
             .sorted()
             .try_collect1()
             .unwrap();
-        assert_eq!(finder.files(vec![PathBuf::from("tests")])?, Some(expect));
+        assert_eq!(finder.files(&[Utf8PathBuf::from("tests")])?, Some(expect));
         Ok(())
     }
 
@@ -952,7 +1014,7 @@ mod tests {
             .sorted()
             .try_collect1()
             .unwrap();
-        assert_eq!(finder.files(vec![PathBuf::from(".")])?, Some(expect));
+        assert_eq!(finder.files(&[Utf8PathBuf::from(".")])?, Some(expect));
         Ok(())
     }
 
@@ -965,11 +1027,11 @@ mod tests {
         let mut finder = new_finder_with_cwd(Mode::FromCli, helper.precious_root(), cwd)?;
         let expect = ["src/main.rs", "src/module.rs"]
             .iter()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .try_collect1()
             .unwrap();
         assert_eq!(
-            finder.files(vec![PathBuf::from("main.rs"), PathBuf::from("module.rs")])?,
+            finder.files(&[Utf8PathBuf::from("main.rs"), Utf8PathBuf::from("module.rs")])?,
             Some(expect),
         );
         Ok(())
@@ -979,7 +1041,7 @@ mod tests {
     #[parallel]
     fn cli_mode_given_dir_with_excluded_files() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut finder = new_finder_with_excludes(
             Mode::FromCli,
             helper.precious_root(),
@@ -987,7 +1049,7 @@ mod tests {
             vec!["vendor/**/*".to_string()],
         )?;
         assert_eq!(
-            finder.files(vec![PathBuf::from(".")])?,
+            finder.files(&[Utf8PathBuf::from(".")])?,
             Some(helper.all_files1()),
         );
         Ok(())
@@ -997,7 +1059,7 @@ mod tests {
     #[parallel]
     fn cli_mode_given_dir_with_excluded_files_bare_dir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut finder = new_finder_with_excludes(
             Mode::FromCli,
             helper.precious_root(),
@@ -1005,7 +1067,7 @@ mod tests {
             vec!["vendor".to_string()],
         )?;
         assert_eq!(
-            finder.files(vec![PathBuf::from(".")])?,
+            finder.files(&[Utf8PathBuf::from(".")])?,
             Some(helper.all_files1()),
         );
         Ok(())
@@ -1015,7 +1077,7 @@ mod tests {
     #[parallel]
     fn cli_mode_given_dir_with_excluded_files_in_subdir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut cwd = helper.precious_root();
         cwd.push("src");
         let mut finder = new_finder_with_excludes(
@@ -1031,10 +1093,10 @@ mod tests {
             "src/sub/mod.rs",
         ]
         .iter()
-        .map(PathBuf::from)
+        .map(Utf8PathBuf::from)
         .try_collect1()
         .unwrap();
-        assert_eq!(finder.files(vec![PathBuf::from(".")])?, Some(expect));
+        assert_eq!(finder.files(&[Utf8PathBuf::from(".")])?, Some(expect));
         Ok(())
     }
 
@@ -1042,19 +1104,17 @@ mod tests {
     #[parallel]
     fn cli_mode_given_files_with_excluded_files() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut finder = new_finder_with_excludes(
             Mode::FromCli,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        let expect = vec1![helper.all_files().pop().unwrap()];
-        let cli_paths = vec![
-            helper.all_files().pop().unwrap(),
-            PathBuf::from("vendor/foo/bar.txt"),
-        ];
-        assert_eq!(finder.files(cli_paths)?, Some(expect));
+        let last_file = helper.all_files().pop().unwrap();
+        let expect = vec1![last_file.clone()];
+        let cli_paths = vec![last_file, Utf8PathBuf::from("vendor/foo/bar.txt")];
+        assert_eq!(finder.files(&cli_paths)?, Some(expect));
         Ok(())
     }
 
@@ -1062,7 +1122,7 @@ mod tests {
     #[parallel]
     fn cli_mode_given_files_with_excluded_files_in_subdir() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("src/main.rs"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("src/main.rs"), "initial content")?;
         let mut cwd = helper.precious_root();
         cwd.push("src");
         let mut finder = new_finder_with_excludes(
@@ -1073,11 +1133,14 @@ mod tests {
         )?;
         let expect = ["src/module.rs"]
             .iter()
-            .map(PathBuf::from)
+            .map(Utf8PathBuf::from)
             .try_collect1()
             .unwrap();
-        let cli_paths = ["main.rs", "module.rs"].iter().map(PathBuf::from).collect();
-        assert_eq!(finder.files(cli_paths)?, Some(expect));
+        let cli_paths = ["main.rs", "module.rs"]
+            .iter()
+            .map(Utf8PathBuf::from)
+            .collect::<Vec<_>>();
+        assert_eq!(finder.files(&cli_paths)?, Some(expect));
         Ok(())
     }
 
@@ -1085,14 +1148,14 @@ mod tests {
     #[parallel]
     fn cli_mode_given_dir_all_excluded_singular() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut finder = new_finder_with_excludes(
             Mode::FromCli,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        let res = finder.files(vec![PathBuf::from("vendor")]);
+        let res = finder.files(&[Utf8PathBuf::from("vendor")]);
         assert!(res.is_err());
         let err = res.unwrap_err();
         assert!(
@@ -1109,14 +1172,14 @@ mod tests {
     #[parallel]
     fn cli_mode_given_dir_all_excluded_multiple() -> Result<()> {
         let helper = testhelper::TestHelper::new()?.with_git_repo()?;
-        helper.write_file(PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
+        helper.write_file(Utf8PathBuf::from("vendor/foo/bar.txt"), "initial content")?;
         let mut finder = new_finder_with_excludes(
             Mode::FromCli,
             helper.precious_root(),
             helper.precious_root(),
             vec!["vendor/**/*".to_string()],
         )?;
-        let res = finder.files(vec![PathBuf::from("vendor"), PathBuf::from("vendor")]);
+        let res = finder.files(&[Utf8PathBuf::from("vendor"), Utf8PathBuf::from("vendor")]);
         assert!(res.is_err());
         let err = res.unwrap_err();
         assert!(
@@ -1136,16 +1199,45 @@ mod tests {
         let mut finder = new_finder(Mode::FromCli, helper.precious_root())?;
         let cli_paths = vec![
             helper.all_files()[0].clone(),
-            PathBuf::from("does/not/exist"),
+            Utf8PathBuf::from("does/not/exist"),
         ];
-        let res = finder.files(cli_paths);
+        let res = finder.files(&cli_paths);
         assert!(res.is_err());
         let err = res.unwrap_err();
         assert_eq!(
             err.downcast_ref(),
             Some(&FinderError::NonExistentPathOnCli {
-                path: PathBuf::from("does/not/exist")
+                path: Utf8PathBuf::from("does/not/exist")
             })
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[parallel]
+    fn cli_mode_given_path_outside_project_root() -> Result<()> {
+        // When precious_root is a subdir of git_root, a file that exists in
+        // git_root but above precious_root is outside the project root and
+        // path_relative_to_project_root must reject it with PrefixNotFound.
+        let helper = testhelper::TestHelper::new()?
+            .with_precious_root_in_subdir("subdir")
+            .with_git_repo()?;
+        let project_root = helper.precious_root();
+        let canonical_project_root = project_root.canonicalize_utf8()?;
+        let mut outside = helper.git_root();
+        outside.push("outside.txt");
+        std::fs::write(&outside, b"content")?;
+
+        let mut finder = new_finder(Mode::FromCli, project_root)?;
+        let err = finder
+            .files(&[outside.clone()])
+            .expect_err("expected PrefixNotFound");
+        assert_eq!(
+            err.downcast_ref(),
+            Some(&FinderError::PrefixNotFound {
+                path: outside,
+                prefix: canonical_project_root,
+            }),
         );
         Ok(())
     }

--- a/precious-core/src/paths/matcher.rs
+++ b/precious-core/src/paths/matcher.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
+use camino::Utf8Path;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use std::path::Path;
 
 #[derive(Debug)]
 #[allow(clippy::module_name_repetitions)]
@@ -10,9 +10,9 @@ pub struct MatcherBuilder {
 
 #[allow(clippy::new_without_default)]
 impl MatcherBuilder {
-    pub fn new<P: AsRef<Path>>(root: P) -> Self {
+    pub fn new<P: AsRef<Utf8Path>>(root: P) -> Self {
         Self {
-            builder: GitignoreBuilder::new(root),
+            builder: GitignoreBuilder::new(root.as_ref()),
         }
     }
 
@@ -41,7 +41,7 @@ pub struct Matcher {
 }
 
 impl Matcher {
-    pub fn path_matches(&self, path: &Path, is_dir: bool) -> bool {
+    pub fn path_matches(&self, path: &Utf8Path, is_dir: bool) -> bool {
         self.gitignore
             .matched_path_or_any_parents(path, is_dir)
             .is_ignore()
@@ -51,6 +51,7 @@ impl Matcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use camino::Utf8Path;
     use serial_test::parallel;
 
     #[test]
@@ -113,11 +114,14 @@ mod tests {
             let globs = t.globs.join(" ");
             let m = MatcherBuilder::new("/").with(t.globs)?.build()?;
             for y in t.yes {
-                assert!(m.path_matches(Path::new(y), false), "{y} matches [{globs}]");
+                assert!(
+                    m.path_matches(Utf8Path::new(y), false),
+                    "{y} matches [{globs}]"
+                );
             }
             for n in t.no {
                 assert!(
-                    !m.path_matches(Path::new(n), false),
+                    !m.path_matches(Utf8Path::new(n), false),
                     "{n} does not match [{globs}]",
                 );
             }

--- a/precious-core/src/paths/utf8.rs
+++ b/precious-core/src/paths/utf8.rs
@@ -1,0 +1,183 @@
+use std::{
+    error::Error,
+    fmt,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonUtf8Source {
+    FilesystemWalk,
+    GitDiff,
+    GitRoot,
+    Cwd,
+    DerivedPath,
+}
+
+impl fmt::Display for NonUtf8Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::FilesystemWalk => "filesystem walk",
+            Self::GitDiff => "git diff",
+            Self::GitRoot => "git rev-parse --show-toplevel",
+            Self::Cwd => "current working directory",
+            Self::DerivedPath => "derived path",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct NonUtf8PathError {
+    pub raw: PathBuf,
+    pub source: NonUtf8Source,
+}
+
+impl fmt::Display for NonUtf8PathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#"non-UTF-8 path from {}: "{}" (raw bytes: "{}")"#,
+            self.source,
+            self.raw.display(),
+            escape_raw(&self.raw),
+        )
+    }
+}
+
+impl Error for NonUtf8PathError {}
+
+/// Build a `PathBuf` from raw bytes when reconstructing a non-UTF-8 path for
+/// error reporting. On unix the bytes are preserved as-is; on other platforms
+/// `OsStr` is not byte-addressable, so we fall back to a lossy decode (the
+/// resulting `PathBuf` is informational only — camino prevents the rest of the
+/// program from ever seeing it).
+pub(crate) fn bytes_to_pathbuf(bytes: &[u8]) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        PathBuf::from(std::ffi::OsStr::from_bytes(bytes))
+    }
+    #[cfg(not(unix))]
+    {
+        PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+fn escape_raw(path: &Path) -> String {
+    #[cfg(unix)]
+    {
+        use std::fmt::Write as _;
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = path.as_os_str().as_bytes();
+        let mut out = String::with_capacity(bytes.len());
+        for &b in bytes {
+            if (0x20..0x7f).contains(&b) && b != b'\\' && b != b'"' {
+                out.push(b as char);
+            } else {
+                let _ = write!(out, r"\x{b:02x}");
+            }
+        }
+        out
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On non-unix platforms `OsStr` is not byte-addressable; the lossy
+        // string form is the best we can do. camino still enforces UTF-8 by
+        // construction, so this branch is informational only.
+        path.to_string_lossy().into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[cfg(unix)]
+    #[test]
+    fn display_filesystem_walk() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"data\xff.bin"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::FilesystemWalk,
+        };
+        assert_eq!(
+            err.to_string(),
+            "non-UTF-8 path from filesystem walk: \"data\u{fffd}.bin\" (raw bytes: \"data\\xff.bin\")",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_git_diff() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"a\xc3\x28b"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::GitDiff,
+        };
+        let s = err.to_string();
+        assert!(s.starts_with("non-UTF-8 path from git diff:"), "{s}");
+        assert!(s.contains(r#"raw bytes: "a\xc3(b""#), "{s}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_git_root() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"/repo\xff"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::GitRoot,
+        };
+        let s = err.to_string();
+        assert!(
+            s.starts_with("non-UTF-8 path from git rev-parse --show-toplevel:"),
+            "{s}",
+        );
+        assert!(s.contains(r"\xff"), "{s}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_cwd() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"/tmp/\xfe"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::Cwd,
+        };
+        let s = err.to_string();
+        assert!(
+            s.starts_with("non-UTF-8 path from current working directory:"),
+            "{s}",
+        );
+        assert!(s.contains(r"\xfe"), "{s}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_derived_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let raw = PathBuf::from(OsStr::from_bytes(b"/canon/\xfd"));
+        let err = NonUtf8PathError {
+            raw,
+            source: NonUtf8Source::DerivedPath,
+        };
+        let s = err.to_string();
+        assert!(s.starts_with("non-UTF-8 path from derived path:"), "{s}");
+        assert!(s.contains(r"\xfd"), "{s}");
+    }
+}

--- a/precious-core/src/precious.rs
+++ b/precious-core/src/precious.rs
@@ -7,6 +7,7 @@ use crate::{
     vcs,
 };
 use anyhow::{Context, Error, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::{ArgAction, ArgGroup, Parser};
 use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
 use fern::{
@@ -20,10 +21,8 @@ use rayon::{prelude::*, ThreadPool, ThreadPoolBuilder};
 use std::{
     env,
     fmt::Write,
-    fs,
     io::stdout,
     num::NonZeroUsize,
-    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 use thiserror::Error;
@@ -33,8 +32,8 @@ enum PreciousError {
     #[error("No mode or paths were provided in the command line args")]
     NoModeOrPathsInCliArgs,
 
-    #[error("The path given in --config, {}, has no parent directory", file.display())]
-    ConfigFileHasNoParent { file: PathBuf },
+    #[error("The path given in --config, {file}, has no parent directory")]
+    ConfigFileHasNoParent { file: Utf8PathBuf },
 
     #[error("Could not find a VCS checkout root starting from {cwd:}")]
     CannotFindRoot { cwd: String },
@@ -70,7 +69,7 @@ impl From<Error> for Exit {
 struct ActionFailure {
     error: String,
     config_key: String,
-    paths: Vec<PathBuf>,
+    paths: Vec<Utf8PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -84,7 +83,7 @@ struct ActionFailure {
 pub struct App {
     /// Path to the precious config file
     #[clap(long, short)]
-    config: Option<PathBuf>,
+    config: Option<Utf8PathBuf>,
     /// Number of parallel jobs (threads) to run (defaults to one per core)
     #[clap(long, short)]
     jobs: Option<usize>,
@@ -160,7 +159,7 @@ pub struct CommonArgs {
     label: Option<String>,
     /// A list of paths on which to operate
     #[clap(value_parser)]
-    paths: Vec<PathBuf>,
+    paths: Vec<Utf8PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -187,7 +186,7 @@ pub struct ConfigInitArgs {
     #[clap(long, short)]
     auto: bool,
     #[clap(long, short, default_value = "precious.toml")]
-    path: PathBuf,
+    path: Utf8PathBuf,
 }
 
 #[must_use]
@@ -253,19 +252,22 @@ impl App {
     }
 
     fn run_with_output(self, output: impl std::io::Write) -> Result<i8> {
+        let cwd = current_dir_utf8()?;
+
         if let Subcommand::Config(config_args) = &self.subcommand {
             if let ConfigSubcommand::Init(init_args) = &config_args.subcommand {
                 config_init::write_config_files(
                     init_args.auto,
                     &init_args.component,
                     &init_args.path,
+                    &cwd,
                 )
                 .context("Failed to initialize config files")?;
                 return Ok(0);
             }
         }
 
-        let (cwd, project_root, config_file, config) = self.load_config()?;
+        let (cwd, project_root, config_file, config) = self.load_config(cwd)?;
 
         match self.subcommand {
             Subcommand::Lint(_) | Subcommand::Tidy(_) => {
@@ -290,54 +292,65 @@ impl App {
     // This exists to make writing tests of the runner easier.
     #[cfg(test)]
     fn new_lint_or_tidy_runner(self) -> Result<LintOrTidyRunner> {
-        let (cwd, project_root, _, config) = self.load_config()?;
+        let cwd = current_dir_utf8()?;
+        let (cwd, project_root, _, config) = self.load_config(cwd)?;
         LintOrTidyRunner::new(self, cwd, project_root, config)
     }
 
-    fn load_config(&self) -> Result<(PathBuf, PathBuf, PathBuf, config::Config)> {
-        let cwd = env::current_dir().context("Failed to get current working directory")?;
+    fn load_config(
+        &self,
+        cwd: Utf8PathBuf,
+    ) -> Result<(Utf8PathBuf, Utf8PathBuf, Utf8PathBuf, config::Config)> {
         let project_root = project_root(self.config.as_deref(), &cwd)
             .context("Failed to determine project root")?;
         let config_file = self.config_file(&project_root);
         let config = config::Config::new(&config_file)
-            .with_context(|| format!("Failed to load config from {}", config_file.display()))?;
+            .with_context(|| format!("Failed to load config from {config_file}"))?;
 
         Ok((cwd, project_root, config_file, config))
     }
 
-    fn config_file(&self, dir: &Path) -> PathBuf {
+    fn config_file(&self, dir: &Utf8Path) -> Utf8PathBuf {
         if let Some(cf) = self.config.as_ref() {
-            debug!("Loading config from {} (set via flag)", cf.display());
+            debug!("Loading config from {cf} (set via flag)");
             return cf.clone();
         }
 
         let default = default_config_file(dir);
-        debug!(
-            "Loading config from {} (default location)",
-            default.display()
-        );
+        debug!("Loading config from {default} (default location)");
         default
     }
 }
 
-fn project_root(config_file: Option<&Path>, cwd: &Path) -> Result<PathBuf> {
+fn current_dir_utf8() -> Result<Utf8PathBuf> {
+    let cwd_std = env::current_dir().context("Failed to get current working directory")?;
+    Utf8PathBuf::try_from(cwd_std).map_err(|e| {
+        crate::paths::utf8::NonUtf8PathError {
+            raw: e.into_path_buf(),
+            source: crate::paths::utf8::NonUtf8Source::Cwd,
+        }
+        .into()
+    })
+}
+
+fn project_root(config_file: Option<&Utf8Path>, cwd: &Utf8Path) -> Result<Utf8PathBuf> {
     if let Some(file) = config_file {
         if let Some(p) = file.parent() {
-            if p.to_string_lossy().is_empty() {
-                return Ok(cwd.to_path_buf());
+            if p.as_str().is_empty() {
+                return Ok(cwd.to_owned());
             }
-            return fs::canonicalize(p).with_context(|| {
-                format!("Canonicalizing config file parent path {}", p.display())
-            });
+            return p
+                .canonicalize_utf8()
+                .with_context(|| format!("Failed to canonicalize config file parent path {p}"));
         }
         return Err(PreciousError::ConfigFileHasNoParent {
-            file: file.to_path_buf(),
+            file: file.to_owned(),
         }
         .into());
     }
 
     if has_config_file(cwd) {
-        return Ok(cwd.into());
+        return Ok(cwd.to_owned());
     }
 
     for ancestor in cwd.ancestors() {
@@ -347,22 +360,22 @@ fn project_root(config_file: Option<&Path>, cwd: &Path) -> Result<PathBuf> {
     }
 
     Err(PreciousError::CannotFindRoot {
-        cwd: cwd.to_string_lossy().to_string(),
+        cwd: cwd.to_string(),
     }
     .into())
 }
 
-fn has_config_file(dir: &Path) -> bool {
+fn has_config_file(dir: &Utf8Path) -> bool {
     default_config_file(dir).exists()
 }
 
 const CONFIG_FILE_NAMES: &[&str] = &["precious.toml", ".precious.toml"];
 
-fn default_config_file(dir: &Path) -> PathBuf {
+fn default_config_file(dir: &Utf8Path) -> Utf8PathBuf {
     CONFIG_FILE_NAMES
         .iter()
         .map(|n| {
-            let mut path = dir.to_path_buf();
+            let mut path = dir.to_owned();
             path.push(n);
             path
         })
@@ -370,9 +383,9 @@ fn default_config_file(dir: &Path) -> PathBuf {
         .expect("This cannot fail because we know CONFIG_FILE_NAMES is not empty")
 }
 
-fn is_checkout_root(dir: &Path) -> bool {
+fn is_checkout_root(dir: &Utf8Path) -> bool {
     for subdir in vcs::DIRS {
-        let mut poss = PathBuf::from(dir);
+        let mut poss = dir.to_owned();
         poss.push(subdir);
         if poss.exists() {
             return true;
@@ -383,10 +396,10 @@ fn is_checkout_root(dir: &Path) -> bool {
 
 fn print_config(
     mut output: impl std::io::Write,
-    config_file: &Path,
+    config_file: &Utf8Path,
     config: config::Config,
 ) -> Result<()> {
-    writeln!(output, "Found config file at: {}", config_file.display())?;
+    writeln!(output, "Found config file at: {config_file}")?;
     writeln!(output)?;
 
     let mut table = Table::new();
@@ -414,8 +427,8 @@ fn print_config(
 #[derive(Debug)]
 pub struct LintOrTidyRunner {
     mode: paths::mode::Mode,
-    project_root: PathBuf,
-    cwd: PathBuf,
+    project_root: Utf8PathBuf,
+    cwd: Utf8PathBuf,
     config: config::Config,
     command: Option<String>,
     chars: chars::Chars,
@@ -423,7 +436,7 @@ pub struct LintOrTidyRunner {
     color: bool,
     thread_pool: ThreadPool,
     should_lint: bool,
-    paths: Vec<PathBuf>,
+    paths: Vec<Utf8PathBuf>,
     label: Option<String>,
 }
 
@@ -438,8 +451,8 @@ macro_rules! maybe_println {
 impl LintOrTidyRunner {
     fn new(
         app: App,
-        cwd: PathBuf,
-        project_root: PathBuf,
+        cwd: Utf8PathBuf,
+        project_root: Utf8PathBuf,
         config: config::Config,
     ) -> Result<LintOrTidyRunner> {
         if log::log_enabled!(log::Level::Debug) {
@@ -569,7 +582,11 @@ impl LintOrTidyRunner {
         run_command: R,
     ) -> Result<Exit>
     where
-        R: Fn(&mut Self, &Slice1<PathBuf>, &command::Command) -> Result<Option<Vec<ActionFailure>>>,
+        R: Fn(
+            &mut Self,
+            &Slice1<Utf8PathBuf>,
+            &command::Command,
+        ) -> Result<Option<Vec<ActionFailure>>>,
     {
         if commands.is_empty() {
             if let Some(c) = &self.command {
@@ -604,7 +621,7 @@ impl LintOrTidyRunner {
         let finder_result = self
             .finder()
             .context("Failed to create file finder")?
-            .files(cli_paths);
+            .files(&cli_paths);
 
         let files = match finder_result {
             Err(e) => return Err(e.context(format!("Failed to find files for {action}"))),
@@ -663,7 +680,7 @@ impl LintOrTidyRunner {
                         "  {} [{}] failed for [{}]\n    {}\n",
                         self.chars.bullet,
                         af.config_key,
-                        af.paths.iter().map(|p| p.to_string_lossy()).join(" "),
+                        af.paths.iter().map(|p| p.as_str()).join(" "),
                         af.error,
                     );
                     out
@@ -688,12 +705,12 @@ impl LintOrTidyRunner {
 
     fn run_one_tidier(
         &mut self,
-        files: &Slice1<PathBuf>,
+        files: &Slice1<Utf8PathBuf>,
         t: &command::Command,
     ) -> Result<Option<Vec<ActionFailure>>> {
         let runner = |s: &Self,
                       actual_invoke: ActualInvoke,
-                      files: &Slice1<&Path>|
+                      files: &Slice1<&Utf8Path>|
          -> Option<Result<(), ActionFailure>> {
             match t.tidy(actual_invoke, files) {
                 Ok(Some(TidyOutcome::Changed)) => {
@@ -737,7 +754,7 @@ impl LintOrTidyRunner {
                     Some(Err(ActionFailure {
                         error: format!("{e:#}"),
                         config_key: t.config_key(),
-                        paths: files.iter().map(|f| f.to_path_buf()).collect(),
+                        paths: files.iter().map(|f| (*f).to_owned()).collect(),
                     }))
                 }
             }
@@ -748,12 +765,12 @@ impl LintOrTidyRunner {
 
     fn run_one_linter(
         &mut self,
-        files: &Slice1<PathBuf>,
+        files: &Slice1<Utf8PathBuf>,
         l: &command::Command,
     ) -> Result<Option<Vec<ActionFailure>>> {
         let runner = |s: &Self,
                       actual_invoke: ActualInvoke,
-                      files: &Slice1<&Path>|
+                      files: &Slice1<&Utf8Path>|
          -> Option<Result<(), ActionFailure>> {
             match l.lint(actual_invoke, files) {
                 Ok(Some(lo)) => {
@@ -784,8 +801,7 @@ impl LintOrTidyRunner {
                                 if files.len() == NonZeroUsize::new(1).unwrap() {
                                     println!(
                                         "::error file={}::Linting with {} failed",
-                                        files[0].display(),
-                                        l.name
+                                        files[0], l.name
                                     );
                                 } else {
                                     println!("::error::Linting with {} failed", l.name);
@@ -796,7 +812,7 @@ impl LintOrTidyRunner {
                         Some(Err(ActionFailure {
                             error: "linting failed".into(),
                             config_key: l.config_key(),
-                            paths: files.iter().map(|f| f.to_path_buf()).collect(),
+                            paths: files.iter().map(|f| (*f).to_owned()).collect(),
                         }))
                     }
                 }
@@ -811,7 +827,7 @@ impl LintOrTidyRunner {
                     Some(Err(ActionFailure {
                         error: format!("{e:#}"),
                         config_key: l.config_key(),
-                        paths: files.iter().map(|f| f.to_path_buf()).collect(),
+                        paths: files.iter().map(|f| (*f).to_owned()).collect(),
                     }))
                 }
             }
@@ -823,12 +839,12 @@ impl LintOrTidyRunner {
     fn run_parallel<R>(
         &mut self,
         what: &str,
-        files: &Slice1<PathBuf>,
+        files: &Slice1<Utf8PathBuf>,
         c: &command::Command,
         runner: R,
     ) -> Result<Option<Vec<ActionFailure>>>
     where
-        R: Fn(&Self, ActualInvoke, &Slice1<&Path>) -> Option<Result<(), ActionFailure>> + Sync,
+        R: Fn(&Self, ActualInvoke, &Slice1<&Utf8Path>) -> Option<Result<(), ActionFailure>> + Sync,
     {
         let (sets, actual_invoke) = c.files_to_args_sets(files).with_context(|| {
             format!(
@@ -912,15 +928,14 @@ fn format_duration(d: &Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use camino::Utf8PathBuf;
     use itertools::Itertools;
     use precious_testhelper::TestHelper;
     use pretty_assertions::assert_eq;
     use pushd::Pushd;
     // Anything that does pushd must be run serially or else chaos ensues.
     use serial_test::serial;
-    #[cfg(not(target_os = "windows"))]
-    use std::str::FromStr;
-    use std::{collections::HashMap, path::PathBuf};
+    use std::collections::HashMap;
     use test_case::test_case;
     #[cfg(not(target_os = "windows"))]
     use which::which;
@@ -946,7 +961,7 @@ lint-failure-exit-codes = [1]
 
             let app = App::try_parse_from(["precious", "tidy", "--all"])?;
 
-            let (_, project_root, config_file, _) = app.load_config()?;
+            let (_, project_root, config_file, _) = app.load_config(current_dir_utf8()?)?;
             let mut expect_config_file = project_root;
             expect_config_file.push(name);
             assert_eq!(config_file, expect_config_file);
@@ -980,15 +995,12 @@ lint-failure-exit-codes = [1]
         let app = App::try_parse_from([
             "precious",
             "--config",
-            helper
-                .config_file(DEFAULT_CONFIG_FILE_NAME)
-                .to_str()
-                .unwrap(),
+            helper.config_file(DEFAULT_CONFIG_FILE_NAME).as_str(),
             "tidy",
             "--all",
         ])?;
 
-        let (_, project_root, config_file, _) = app.load_config()?;
+        let (_, project_root, config_file, _) = app.load_config(current_dir_utf8()?)?;
         let mut expect_config_file = project_root;
         expect_config_file.push(DEFAULT_CONFIG_FILE_NAME);
         assert_eq!(config_file, expect_config_file);
@@ -1030,9 +1042,10 @@ lint-failure-exit-codes = [1]
             helper.pushd_to_subdir()?
         };
 
-        let cwd = env::current_dir()?;
+        let cwd_std = env::current_dir()?;
+        let cwd = Utf8PathBuf::try_from(cwd_std).unwrap();
 
-        let root = super::project_root(config_file.map(Path::new), &cwd)?;
+        let root = super::project_root(config_file.map(Utf8Path::new), &cwd)?;
         assert_eq!(root, helper.precious_root());
 
         Ok(())
@@ -1128,9 +1141,13 @@ lint-failure-exit-codes = [1]
         let mut lt = app.new_lint_or_tidy_runner()?;
 
         assert_eq!(
-            lt.finder()?
-                .files(paths.iter().map(PathBuf::from).collect())?,
-            Some(expect.iter1().map(PathBuf::from).collect1()),
+            lt.finder()?.files(
+                &paths
+                    .iter()
+                    .map(|p| Utf8PathBuf::from(*p))
+                    .collect::<Vec<_>>()
+            )?,
+            Some(expect.iter1().map(|p| Utf8PathBuf::from(*p)).collect1()),
             "finder_uses_project_root: {} [{}]",
             if flag.is_empty() { "<none>" } else { flag },
             paths.join(" ")
@@ -1295,7 +1312,7 @@ lint-failure-exit-codes = [1]
             lint-failure-exit-codes = [1]
         "#;
         let helper = TestHelper::new()?.with_config_file(DEFAULT_CONFIG_FILE_NAME, config)?;
-        let test_replace = PathBuf::from_str("test.replace")?;
+        let test_replace = Utf8PathBuf::from("test.replace");
         helper.write_file(&test_replace, "The letter A")?;
         let _pushd = helper.pushd_to_git_root()?;
 
@@ -1305,7 +1322,7 @@ lint-failure-exit-codes = [1]
 
         assert_eq!(status, 0);
 
-        let content = helper.read_file(test_replace.as_ref())?;
+        let content = helper.read_file(&test_replace)?;
         assert_eq!(content, "The letter b".to_string());
 
         Ok(())
@@ -1357,7 +1374,7 @@ lint-failure-exit-codes = [1]
 │ baz  ┆ both ┆ baz --fast-mode --no-verify          │
 └──────┴──────┴──────────────────────────────────────┘
 "#,
-            helper.config_file(DEFAULT_CONFIG_FILE_NAME).display(),
+            helper.config_file(DEFAULT_CONFIG_FILE_NAME),
         );
         assert_eq!(output, expect);
 

--- a/precious-helpers/Cargo.toml
+++ b/precious-helpers/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true
+camino.workspace = true
 itertools.workspace = true
 log.workspace = true
 regex.workspace = true

--- a/precious-helpers/src/exec.rs
+++ b/precious-helpers/src/exec.rs
@@ -2,6 +2,7 @@
 use crate::error::Error;
 use anyhow::{Context, Result};
 use bon::bon;
+use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 use log::{
     Level::{Debug, Info},
@@ -10,8 +11,7 @@ use log::{
 use regex::Regex;
 use std::{
     collections::HashMap,
-    env, fs,
-    path::Path,
+    env,
     process::{self, Command},
     sync::mpsc::{self, RecvTimeoutError},
     thread::{self, JoinHandle},
@@ -34,7 +34,7 @@ pub struct Exec<'a> {
     env: HashMap<String, String>,
     ok_exit_codes: &'a [i32],
     ignore_stderr: Vec<Regex>,
-    in_dir: Option<&'a Path>,
+    in_dir: Option<&'a Utf8Path>,
     pub loggable_command: String,
 }
 
@@ -43,6 +43,7 @@ pub struct Output {
     pub exit_code: i32,
     pub stdout: Option<String>,
     pub stderr: Option<String>,
+    pub stdout_bytes: Option<Vec<u8>>,
 }
 
 #[bon]
@@ -55,7 +56,7 @@ impl<'a> Exec<'a> {
         #[builder(default)] env: HashMap<String, String>,
         ok_exit_codes: &'a [i32],
         #[builder(default)] ignore_stderr: Vec<Regex>,
-        in_dir: Option<&'a Path>,
+        in_dir: Option<&'a Utf8Path>,
     ) -> Self {
         let mut s = Self {
             exe,
@@ -145,15 +146,17 @@ impl<'a> Exec<'a> {
             .with_context(|| format!(r"Failed to execute command `{}`", self.full_command()))?;
 
         if log_enabled!(Debug) && !output.stdout.is_empty() {
-            let stdout = String::from_utf8(output.stdout.clone())
-                .context("Failed to decode stdout as UTF-8")?;
+            // Lossy decode is intentional: a process whose stdout is byte-faithful
+            // (e.g. `git ls-files -z`) may produce bytes that are not valid UTF-8.
+            // Surfacing those bytes is the caller's job via `stdout_bytes`; here we
+            // only want a readable log line.
+            let stdout = String::from_utf8_lossy(&output.stdout);
             debug!("Stdout was:\n{stdout}");
         }
 
         let code = output.status.code().unwrap_or(-1);
         if !output.stderr.is_empty() {
-            let stderr = String::from_utf8(output.stderr.clone())
-                .context("Failed to decode stderr as UTF-8")?;
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
             if log_enabled!(Debug) {
                 debug!("Stderr was:\n{stderr}");
             }
@@ -162,18 +165,22 @@ impl<'a> Exec<'a> {
                 return Err(Error::UnexpectedStderr {
                     cmd: self.full_command(),
                     code,
-                    stdout: String::from_utf8(output.stdout)
-                        .unwrap_or("<could not turn stdout into a UTF-8 string>".to_string()),
+                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
                     stderr,
                 }
                 .into());
             }
         }
 
+        let stdout_string = bytes_to_option_string(&output.stdout);
+        let stderr_string = bytes_to_option_string(&output.stderr);
+        let stdout_bytes = (!output.stdout.is_empty()).then_some(output.stdout);
+
         Ok(Output {
             exit_code: code,
-            stdout: bytes_to_option_string(&output.stdout),
-            stderr: bytes_to_option_string(&output.stderr),
+            stdout: stdout_string,
+            stderr: stderr_string,
+            stdout_bytes,
         })
     }
 
@@ -207,10 +214,8 @@ impl<'a> Exec<'a> {
             return if self.ok_exit_codes.contains(&code) {
                 Ok(output)
             } else {
-                let stdout = String::from_utf8(output.stdout)
-                    .context("Failed to decode command stdout as UTF-8")?;
-                let stderr = String::from_utf8(output.stderr)
-                    .context("Failed to decode command stderr as UTF-8")?;
+                let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
                 Err(Error::UnexpectedExitCode {
                     cmd: self.full_command(),
                     code,
@@ -238,10 +243,8 @@ impl<'a> Exec<'a> {
             self.full_command(),
             signal
         );
-        let stdout = String::from_utf8(output.stdout)
-            .context("Failed to decode command stdout as UTF-8 for signal error")?;
-        let stderr = String::from_utf8(output.stderr)
-            .context("Failed to decode command stderr as UTF-8 for signal error")?;
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         Err(Error::ProcessKilledBySignal {
             cmd: self.full_command(),
             signal,
@@ -282,13 +285,11 @@ impl<'a> Exec<'a> {
         cmd.args(&self.args);
 
         let in_dir = if let Some(d) = &self.in_dir {
-            d.to_path_buf()
+            d.canonicalize_utf8()?
         } else {
-            env::current_dir()?
+            Utf8PathBuf::try_from(env::current_dir()?)?
         };
-
-        let in_dir = fs::canonicalize(in_dir)?;
-        debug!("Setting current dir to {}", in_dir.display());
+        debug!("Setting current dir to {in_dir}");
 
         // We are canonicalizing this primarily for the benefit of our debugging output, because
         // otherwise we might see the current dir as just `.`, which is not helpful.
@@ -333,11 +334,7 @@ mod tests {
     use regex::Regex;
     // Anything that does pushd must be run serially or else chaos ensues.
     use serial_test::{parallel, serial};
-    use std::{
-        collections::HashMap,
-        env, fs,
-        path::{Path, PathBuf},
-    };
+    use std::{collections::HashMap, env, path::Path};
     use tempfile::tempdir;
     use test_case::test_case;
     use which::which;
@@ -748,7 +745,7 @@ STDERR
         }
 
         let td = tempdir()?;
-        let td_path = maybe_canonicalize(td.path())?;
+        let td_path = maybe_canonicalize_tempdir(td.path())?;
 
         let res = Exec::builder()
             .exe("pwd")
@@ -763,11 +760,22 @@ STDERR
         let stdout_trimmed = stdout.trim_end();
         assert_eq!(
             stdout_trimmed,
-            td_path.to_string_lossy(),
+            td_path.as_str(),
             "process runs in another dir",
         );
 
         Ok(())
+    }
+
+    // The temp directory on macOS in GitHub Actions appears to be a symlink, but canonicalizing on
+    // Windows breaks tests for some reason.
+    fn maybe_canonicalize_tempdir(path: &Path) -> Result<camino::Utf8PathBuf> {
+        let utf8 = camino::Utf8PathBuf::try_from(path.to_owned())?;
+        if cfg!(windows) {
+            Ok(utf8)
+        } else {
+            Ok(utf8.canonicalize_utf8()?)
+        }
     }
 
     #[test]
@@ -906,12 +914,24 @@ STDERR
         assert_eq!(exec.loggable_command, expect);
     }
 
-    // The temp directory on macOS in GitHub Actions appears to be a symlink, but
-    // canonicalizing on Windows breaks tests for some reason.
-    fn maybe_canonicalize(path: &Path) -> Result<PathBuf> {
-        if cfg!(windows) {
-            return Ok(path.to_owned());
+    #[test]
+    #[parallel]
+    fn raw_stdout_preserves_non_utf8_bytes() -> Result<()> {
+        if which("sh").is_err() {
+            println!("Skipping test since sh is not in path");
+            return Ok(());
         }
-        Ok(fs::canonicalize(path)?)
+
+        // Use sh -c with printf %b to emit a NUL-separated stream containing an invalid UTF-8 byte.
+        // %b interprets backslash escapes like \0 and \377 (octal for 0xFF).
+        let out = Exec::builder()
+            .exe("sh")
+            .args(vec!["-c", "printf '%b' 'a\\0b\\377\\0'"])
+            .ok_exit_codes(&[0])
+            .build()
+            .run()?;
+        let bytes = out.stdout_bytes.as_deref().expect("expected raw stdout");
+        assert_eq!(bytes, b"a\x00b\xff\x00");
+        Ok(())
     }
 }

--- a/precious-integration/Cargo.toml
+++ b/precious-integration/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
+camino.workspace = true
 itertools.workspace = true
 regex.workspace = true
 precious-core.workspace = true

--- a/precious-integration/src/config_init.rs
+++ b/precious-integration/src/config_init.rs
@@ -253,6 +253,77 @@ fn init_auto() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+#[serial]
+fn init_auto_fails_on_non_utf8_filename() -> Result<()> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    compile_precious()?;
+    let (_td, _pd) = chdir_to_tempdir()?;
+
+    // A real on-disk file whose name is not valid UTF-8. `config init --auto`
+    // walks the cwd to detect components and must fail-fast here.
+    let bad = OsStr::from_bytes(b"data\xff.bin");
+    File::create(bad)?;
+
+    let stderr = run_precious_expecting_failure(&["config", "init", "--auto"])?;
+    assert!(
+        stderr.contains("non-UTF-8 path from filesystem walk"),
+        "expected FilesystemWalk diagnostic, got stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(r"data\xff.bin"),
+        "expected raw-byte escape in stderr, got:\n{stderr}",
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn init_fails_on_non_utf8_cwd() -> Result<()> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    compile_precious()?;
+    let td = tempfile::Builder::new()
+        .prefix("precious-integration-")
+        .tempdir()?;
+
+    // Create a subdirectory with a non-UTF-8 name and chdir into it. Any
+    // precious subcommand, including `config init`, must reject this cwd.
+    let bad_dir = td.path().join(OsStr::from_bytes(b"sub\xff"));
+    fs::create_dir(&bad_dir)?;
+    let _pd = Pushd::new(&bad_dir)?;
+
+    let stderr = run_precious_expecting_failure(&["config", "init", "--component", "go"])?;
+    assert!(
+        stderr.contains("non-UTF-8 path from current working directory"),
+        "expected Cwd diagnostic, got stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(r"sub\xff"),
+        "expected raw-byte escape in stderr, got:\n{stderr}",
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn run_precious_expecting_failure(args: &[&str]) -> Result<String> {
+    use std::process::Command;
+    let precious = precious_path()?;
+    let out = Command::new(&precious).args(args).output()?;
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "expected non-zero exit; stderr was:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    Ok(String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
 fn chdir_to_tempdir() -> Result<(TempDir, Pushd)> {
     let td = tempfile::Builder::new()
         .prefix("precious-integration-")

--- a/precious-integration/src/lint_tidy.rs
+++ b/precious-integration/src/lint_tidy.rs
@@ -138,7 +138,7 @@ fn cli_paths() -> Result<()> {
     let precious = precious_path()?;
 
     let mut args = vec!["lint"];
-    args.append(&mut files.iter().map(|p| p.to_str().unwrap()).collect());
+    args.append(&mut files.iter().map(|p| p.as_str()).collect());
     Exec::builder()
         .exe(&precious)
         .args(args)
@@ -148,7 +148,7 @@ fn cli_paths() -> Result<()> {
         .run()?;
 
     let mut args = vec!["tidy"];
-    args.append(&mut files.iter().map(|p| p.to_str().unwrap()).collect());
+    args.append(&mut files.iter().map(|p| p.as_str()).collect());
     Exec::builder()
         .exe(&precious)
         .args(args)
@@ -645,7 +645,7 @@ ok-exit-codes = 0
         ),
         (
             String::from("PRECIOUS_INTEGRATION_TEST_ROOT"),
-            helper.precious_root().to_string_lossy().to_string(),
+            helper.precious_root().into_string(),
         ),
     ]);
 

--- a/precious-integration/src/non_utf8_paths.rs
+++ b/precious-integration/src/non_utf8_paths.rs
@@ -1,0 +1,137 @@
+use crate::shared::{compile_precious, precious_path};
+use anyhow::Result;
+use precious_helpers::exec::Exec;
+use precious_testhelper::TestHelper;
+use serial_test::serial;
+
+const CONFIG: &str = r#"
+[commands.echo]
+type = "lint"
+include = "**/*"
+cmd = ["true"]
+ok-exit-codes = 0
+lint-failure-exit-codes = 1
+"#;
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn non_utf8_filename_fails_with_clear_error() -> Result<()> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    compile_precious()?;
+    let helper = TestHelper::new()?
+        .with_git_repo()?
+        .with_config_file("precious.toml", CONFIG)?;
+
+    let bad = OsStr::from_bytes(b"data\xff.bin");
+    let mut path = helper.precious_root().into_std_path_buf();
+    path.push(bad);
+    std::fs::write(&path, b"contents")?;
+
+    let precious = precious_path()?;
+    let res = Exec::builder()
+        .exe(&precious)
+        .args(vec!["lint", "--all"])
+        .ok_exit_codes(&[1])
+        .in_dir(&helper.precious_root())
+        .build()
+        .run();
+
+    let err = res.expect_err("expected non-zero exit");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("non-UTF-8 path from filesystem walk"),
+        "expected fail-fast diagnostic, got:\n{msg}",
+    );
+    assert!(
+        msg.contains(r"data\xff.bin"),
+        "expected raw-byte escape in stderr, got:\n{msg}",
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn non_utf8_git_index_entry_fails_with_clear_error() -> Result<()> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    compile_precious()?;
+    let helper = TestHelper::new()?
+        .with_git_repo()?
+        .with_config_file("precious.toml", CONFIG)?;
+
+    // Hash a real blob so the index entry is structurally valid; the blob
+    // contents don't matter — only the path bytes do.
+    let blob_path = helper.precious_root().join("seed.txt");
+    std::fs::write(&blob_path, b"seed")?;
+    let blob_out = Command::new("git")
+        .args(["hash-object", "-w", "seed.txt"])
+        .current_dir(helper.precious_root())
+        .output()?;
+    assert!(blob_out.status.success(), "git hash-object failed");
+    let oid = std::str::from_utf8(&blob_out.stdout)?.trim();
+
+    // Stage a non-UTF-8 path via `git update-index --index-info`, which is the
+    // one git porcelain that accepts raw bytes for the path component.
+    let mut entry: Vec<u8> = format!("100644 {oid}\t").into_bytes();
+    entry.extend_from_slice(b"data\xff.bin\n");
+    let mut child = Command::new("git")
+        .args(["update-index", "--index-info"])
+        .current_dir(helper.precious_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    child.stdin.as_mut().unwrap().write_all(&entry)?;
+    let status = child.wait()?;
+    assert!(status.success(), "git update-index failed");
+
+    let precious = precious_path()?;
+    let res = Exec::builder()
+        .exe(&precious)
+        .args(vec!["lint", "--staged"])
+        .ok_exit_codes(&[1])
+        .in_dir(&helper.precious_root())
+        .build()
+        .run();
+
+    let err = res.expect_err("expected non-zero exit");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("non-UTF-8 path from git diff"),
+        "expected GitDiff diagnostic, got:\n{msg}",
+    );
+    assert!(
+        msg.contains(r"data\xff.bin"),
+        "expected raw-byte escape in stderr, got:\n{msg}",
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn cafe_txt_handled_through_git() -> Result<()> {
+    compile_precious()?;
+    let helper = TestHelper::new()?
+        .with_git_repo()?
+        .with_config_file("precious.toml", CONFIG)?;
+
+    let name = "café.txt";
+    helper.write_file(name, "hello")?;
+    helper.stage_all()?;
+
+    let precious = precious_path()?;
+    Exec::builder()
+        .exe(&precious)
+        .args(vec!["lint", "--staged"])
+        .ok_exit_codes(&[0])
+        .in_dir(&helper.precious_root())
+        .build()
+        .run()?;
+
+    Ok(())
+}

--- a/precious-integration/src/shared.rs
+++ b/precious-integration/src/shared.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
 use precious_helpers::exec::Exec;
 use regex::Regex;
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+use std::env;
 
 pub(crate) fn compile_precious() -> Result<()> {
     let cargo_build_re = Regex::new("Finished.+dev.+target")?;
@@ -13,7 +11,7 @@ pub(crate) fn compile_precious() -> Result<()> {
         .exe("cargo")
         .args(vec!["build", "--package", "precious"])
         .ok_exit_codes(&[0])
-        .in_dir(Path::new(".."))
+        .in_dir(Utf8Path::new(".."))
         .ignore_stderr(vec![cargo_build_re])
         .build()
         .run()?;
@@ -24,10 +22,10 @@ pub(crate) fn precious_path() -> Result<String> {
     let man_dir = env::var("CARGO_MANIFEST_DIR")?;
     assert_ne!(man_dir, "");
 
-    let mut precious = PathBuf::from(man_dir);
+    let mut precious = Utf8PathBuf::from(man_dir);
     precious.push("..");
     precious.push("target");
     precious.push("debug");
     precious.push("precious");
-    Ok(fs::canonicalize(precious)?.to_string_lossy().to_string())
+    Ok(precious.canonicalize_utf8()?.into_string())
 }

--- a/precious-integration/src/tests.rs
+++ b/precious-integration/src/tests.rs
@@ -1,3 +1,4 @@
 mod config_init;
 mod lint_tidy;
+mod non_utf8_paths;
 mod shared;

--- a/precious-testhelper/Cargo.toml
+++ b/precious-testhelper/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+camino.workspace = true
 env_logger.workspace = true
 log.workspace = true
 mitsein.workspace = true

--- a/precious-testhelper/src/lib.rs
+++ b/precious-testhelper/src/lib.rs
@@ -1,15 +1,14 @@
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use log::debug;
 use mitsein::prelude::*;
 use precious_helpers::exec::Exec;
 use pushd::Pushd;
 use regex::Regex;
 use std::{
-    env,
-    ffi::OsString,
-    fs,
+    env, fs,
     io::prelude::*,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{LazyLock, OnceLock},
 };
 use tempfile::TempDir;
@@ -18,11 +17,11 @@ pub struct TestHelper {
     // While we never access this field we need to hold onto the tempdir or
     // else the directory it references will be deleted.
     _tempdir: TempDir,
-    git_root: PathBuf,
-    precious_root: PathBuf,
-    paths: Vec<PathBuf>,
-    root_gitignore_file: PathBuf,
-    tests_data_gitignore_file: PathBuf,
+    git_root: Utf8PathBuf,
+    precious_root: Utf8PathBuf,
+    paths: Vec<Utf8PathBuf>,
+    root_gitignore_file: Utf8PathBuf,
+    tests_data_gitignore_file: Utf8PathBuf,
 }
 
 static RERERE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("Recorded preimage").unwrap());
@@ -58,21 +57,32 @@ impl TestHelper {
             }
         }
 
-        let root = maybe_canonicalize(td.path())?;
+        let root = Self::maybe_canonicalize_tempdir(td.path())?;
 
         let helper = TestHelper {
             _tempdir: td,
             git_root: root.clone(),
             precious_root: root,
-            paths: Self::PATHS.iter().map(PathBuf::from).collect(),
-            root_gitignore_file: PathBuf::from(".gitignore"),
-            tests_data_gitignore_file: PathBuf::from("tests/data/.gitignore"),
+            paths: Self::PATHS.iter().map(Utf8PathBuf::from).collect(),
+            root_gitignore_file: Utf8PathBuf::from(".gitignore"),
+            tests_data_gitignore_file: Utf8PathBuf::from("tests/data/.gitignore"),
         };
         Ok(helper)
     }
 
-    pub fn with_precious_root_in_subdir<P: AsRef<Path>>(mut self, subdir: P) -> Self {
-        self.precious_root.push(subdir);
+    // The temp directory on macOS in GitHub Actions appears to be a symlink, but canonicalizing on
+    // Windows breaks tests for some reason.
+    pub fn maybe_canonicalize_tempdir(path: &Path) -> Result<Utf8PathBuf> {
+        let utf8 = Utf8PathBuf::try_from(path.to_owned())?;
+        if cfg!(windows) {
+            Ok(utf8)
+        } else {
+            Ok(utf8.canonicalize_utf8()?)
+        }
+    }
+
+    pub fn with_precious_root_in_subdir<P: AsRef<Utf8Path>>(mut self, subdir: P) -> Self {
+        self.precious_root.push(subdir.as_ref());
         self
     }
 
@@ -82,7 +92,7 @@ impl TestHelper {
     }
 
     fn create_git_repo(&self) -> Result<()> {
-        debug!("Creating git repo in {}", self.git_root.display());
+        debug!("Creating git repo in {}", self.git_root);
         for p in self.paths.iter() {
             let content = if is_rust_file(p) {
                 "fn foo() {}\n"
@@ -128,27 +138,27 @@ impl TestHelper {
         Ok(Pushd::new(subdir)?)
     }
 
-    pub fn git_root(&self) -> PathBuf {
+    pub fn git_root(&self) -> Utf8PathBuf {
         self.git_root.clone()
     }
 
-    pub fn precious_root(&self) -> PathBuf {
+    pub fn precious_root(&self) -> Utf8PathBuf {
         self.precious_root.clone()
     }
 
-    pub fn config_file(&self, file_name: &str) -> PathBuf {
+    pub fn config_file(&self, file_name: &str) -> Utf8PathBuf {
         let mut path = self.precious_root.clone();
         path.push(file_name);
         path
     }
 
-    pub fn all_files(&self) -> Vec<PathBuf> {
+    pub fn all_files(&self) -> Vec<Utf8PathBuf> {
         let mut files = self.paths.clone();
         files.sort();
         files
     }
 
-    pub fn all_files1(&self) -> Vec1<PathBuf> {
+    pub fn all_files1(&self) -> Vec1<Utf8PathBuf> {
         let mut files = self.paths.clone();
         files.sort();
         files.try_into().unwrap()
@@ -177,14 +187,14 @@ can_ignore.*
 generated.*
 ";
 
-    pub fn non_ignored_files() -> Vec<PathBuf> {
+    pub fn non_ignored_files() -> Vec<Utf8PathBuf> {
         Self::PATHS
             .iter()
             .filter_map(|&p| {
                 if p.contains("can_ignore") || p.contains("bar.") || p.contains("generated.txt") {
                     None
                 } else {
-                    Some(PathBuf::from(p))
+                    Some(Utf8PathBuf::from(p))
                 }
             })
             .collect()
@@ -224,7 +234,7 @@ generated.*
         Ok(())
     }
 
-    pub fn add_gitignore_files(&self) -> Result<Vec<PathBuf>> {
+    pub fn add_gitignore_files(&self) -> Result<Vec<Utf8PathBuf>> {
         self.write_file(&self.root_gitignore_file, Self::ROOT_GITIGNORE)?;
         self.write_file(&self.tests_data_gitignore_file, Self::TESTS_DATA_GITIGNORE)?;
 
@@ -247,9 +257,9 @@ generated.*
 
     const TO_MODIFY: &'static [&'static str] = &["src/module.rs", "tests/data/foo.txt"];
 
-    pub fn modify_files(&self) -> Result<Vec<PathBuf>> {
-        let mut paths: Vec<PathBuf> = vec![];
-        for p in Self::TO_MODIFY.iter().map(PathBuf::from) {
+    pub fn modify_files(&self) -> Result<Vec<Utf8PathBuf>> {
+        let mut paths: Vec<Utf8PathBuf> = vec![];
+        for p in Self::TO_MODIFY.iter().map(Utf8PathBuf::from) {
             let content = if is_rust_file(&p) {
                 "fn bar() {}\n"
             } else {
@@ -262,26 +272,24 @@ generated.*
         Ok(paths)
     }
 
-    pub fn write_file<P: AsRef<Path>>(&self, rel: P, content: &str) -> Result<()> {
+    pub fn write_file<P: AsRef<Utf8Path>>(&self, rel: P, content: &str) -> Result<()> {
         let mut full = self.precious_root.clone();
         full.push(rel.as_ref());
         let parent = full.parent().unwrap();
-        debug!("creating dir at {}", parent.display());
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Creating dir at {}", parent.display()))?;
-        debug!("writing file at {}", full.display());
-        let mut file = fs::File::create(full.clone())
-            .context(format!("Creating file at {}", full.display()))?;
+        debug!("creating dir at {parent}");
+        fs::create_dir_all(parent).with_context(|| format!("Creating dir at {parent}"))?;
+        debug!("writing file at {full}");
+        let mut file = fs::File::create(&full).context(format!("Creating file at {full}"))?;
         file.write_all(content.as_bytes())
-            .context(format!("Writing to file at {}", full.display()))?;
+            .context(format!("Writing to file at {full}"))?;
 
         Ok(())
     }
 
-    pub fn delete_file<P: AsRef<Path>>(&self, rel: P) -> Result<()> {
+    pub fn delete_file<P: AsRef<Utf8Path>>(&self, rel: P) -> Result<()> {
         let mut full = self.precious_root.clone();
         full.push(rel.as_ref());
-        debug!("deleting path at {}", full.display());
+        debug!("deleting path at {full}");
         if full.is_file() {
             return Ok(fs::remove_file(full)?);
         }
@@ -290,29 +298,15 @@ generated.*
     }
 
     #[cfg(not(target_os = "windows"))]
-    pub fn read_file(&self, rel: &Path) -> Result<String> {
+    pub fn read_file(&self, rel: &Utf8Path) -> Result<String> {
         let mut full = self.precious_root.clone();
         full.push(rel);
-        let content = fs::read_to_string(full.clone())
-            .context(format!("Reading file at {}", full.display()))?;
+        let content = fs::read_to_string(&full).context(format!("Reading file at {full}"))?;
 
         Ok(content)
     }
 }
 
-fn is_rust_file(p: &Path) -> bool {
-    if let Some(e) = p.extension() {
-        let rs = OsString::from("rs");
-        return *e == rs;
-    }
-    false
-}
-
-// The temp directory on macOS in GitHub Actions appears to be a symlink, but
-// canonicalizing on Windows breaks tests for some reason.
-pub fn maybe_canonicalize(path: &Path) -> Result<PathBuf> {
-    if cfg!(windows) {
-        return Ok(path.to_owned());
-    }
-    Ok(fs::canonicalize(path)?)
+fn is_rust_file(p: &Utf8Path) -> bool {
+    p.extension() == Some("rs")
 }


### PR DESCRIPTION
This is done by using the camino library for paths.